### PR TITLE
Remove legacy ccao::vars_dict attributes from README.Rmd code

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -67,16 +67,13 @@ Because our office (mostly) cannot observe individual condo unit characteristics
 library(dplyr)
 library(tidyr)
 library(yaml)
-library(httr)
 
 condo_params <- read_yaml("params.yaml")
 condo_preds <- condo_params$model$predictor$all
 
-res_params_text <- GET(
+res_params <- read_yaml(
   "https://raw.githubusercontent.com/ccao-data/model-res-avm/master/params.yaml"
-) %>%
-  content(as = "text")
-res_params <- read_yaml(text = res_params_text)
+)
 res_preds <- res_params$model$predictor$all
 
 condo_unique_preds <- setdiff(condo_preds, res_preds)

--- a/README.Rmd
+++ b/README.Rmd
@@ -67,27 +67,30 @@ Because our office (mostly) cannot observe individual condo unit characteristics
 library(dplyr)
 library(tidyr)
 library(yaml)
-params <- read_yaml("params.yaml")
+library(httr)
+
+condo_params <- read_yaml("params.yaml")
+condo_preds <- condo_params$model$predictor$all
+
+res_params_text <- GET(
+  "https://raw.githubusercontent.com/ccao-data/model-res-avm/master/params.yaml"
+) %>%
+  content(as = "text")
+res_params <- read_yaml(text = res_params_text)
+res_preds <- res_params$model$predictor$all
+
+condo_unique_preds <- setdiff(condo_preds, res_preds)
+
 ccao::vars_dict %>%
-  filter(
-    var_is_predictor,
-    !var_name_model %in% c("meta_sale_price")
-  ) %>%
   inner_join(
-    as_tibble(params$model$predictor$all),
+    as_tibble(condo_preds),
     by = c("var_name_model" = "value")
   ) %>%
-  filter(
-    stringr::str_starts(var_name_model, "char_", negate = TRUE) |
-      var_name_model %in% c("char_yrblt", "char_land_sf") |
-      var_model_type == "condo",
-    stringr::str_starts(var_name_model, "ind_", negate = TRUE)
-  ) %>%
   distinct(
+    var_name_model,
     `Feature Name` = var_name_pretty,
     Category = var_type,
     Type = var_data_type,
-    var_model_type
   ) %>%
   mutate(
     Category = recode(
@@ -106,13 +109,15 @@ ccao::vars_dict %>%
     )
   ) %>%
   mutate(`Unique to Condo Model` = ifelse(
-    var_model_type == "condo" |
+    var_name_model != "loc_tax_municipality_name" & (
+      var_name_model %in% condo_unique_preds |
       `Feature Name` %in%
-        c("Condominium Building Year Built", "Condominium % Ownership"),
+        c("Condominium Building Year Built", "Condominium % Ownership")
+    ),
     "X", ""
   )) %>%
   arrange(desc(`Unique to Condo Model`), Category) %>%
-  select(-var_model_type) %>%
+  select(-var_name_model) %>%
   knitr::kable(format = "markdown")
 ```
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -111,8 +111,8 @@ ccao::vars_dict %>%
   mutate(`Unique to Condo Model` = ifelse(
     var_name_model != "loc_tax_municipality_name" & (
       var_name_model %in% condo_unique_preds |
-      `Feature Name` %in%
-        c("Condominium Building Year Built", "Condominium % Ownership")
+        `Feature Name` %in%
+          c("Condominium Building Year Built", "Condominium % Ownership")
     ),
     "X", ""
   )) %>%

--- a/README.md
+++ b/README.md
@@ -152,12 +152,12 @@ the 2023 assessment model.
 | Percent Population Mobility, Moved From Within Same County in Past Year | acs5           | numeric   |                       |
 | Longitude                                                               | loc            | numeric   |                       |
 | Latitude                                                                | loc            | numeric   |                       |
-| Municipality Name                                                       | loc            | character |                       |
 | FEMA Special Flood Hazard Area                                          | loc            | logical   |                       |
 | First Street Factor                                                     | loc            | numeric   |                       |
 | First Street Risk Direction                                             | loc            | numeric   |                       |
 | School Elementary District GEOID                                        | loc            | character |                       |
 | School Secondary District GEOID                                         | loc            | character |                       |
+| Municipality Name                                                       | loc            | character |                       |
 | CMAP Walkability Score (No Transit)                                     | loc            | numeric   |                       |
 | CMAP Walkability Total Score                                            | loc            | numeric   |                       |
 | Airport Noise DNL                                                       | loc            | numeric   |                       |


### PR DESCRIPTION
This PR updates `README.Rmd` along similar lines as the changes in https://github.com/ccao-data/model-res-avm/pull/18 to remove references to legacy `ccao::vars_dict` attributes that were removed in https://github.com/ccao-data/ccao/pull/6. Instead of getting condo-specific attributes from the vars dict, we now pull the latest residential parameters from the `model-res-avm` repo and diff them against the condo params to generate the column marking condo-specific parameters.