### PR TITLE
Bugfix: Pin `build-and-run-batch-job` workflow ref to `main`

### DIFF
--- a/.github/workflows/build-and-run-model.yaml
+++ b/.github/workflows/build-and-run-model.yaml
@@ -27,7 +27,7 @@ jobs:
       # required in order to allow the reusable called workflow to push to
       # GitHub Container Registry
       packages: write
-    uses: ccao-data/actions/.github/workflows/build-and-run-batch-job.yaml
+    uses: ccao-data/actions/.github/workflows/build-and-run-batch-job.yaml@main
     with:
       vcpu: "16.0"
       memory: "65536"


### PR DESCRIPTION
Merging #9 revealed a bug in the `build-and-run-model.yaml` workflow: When calling a reusable workflow from an external repository, the ref for the workflow always needs to be defined in the `uses:` attribute ([SO source](https://stackoverflow.com/a/73026906)) ([example failed run](https://github.com/ccao-data/model-condo-avm/actions/runs/6870408711/workflow)).

For evidence that this works, note that the `build` step successfully loaded and ran in this workflow run: https://github.com/ccao-data/model-condo-avm/actions/runs/6870496545/job/18685510675?pr=11