### PR TITLE
Set SNS topic env var in `build-and-run-model` workflow container

### DIFF
--- a/.github/workflows/build-and-run-model.yaml
+++ b/.github/workflows/build-and-run-model.yaml
@@ -27,9 +27,8 @@ jobs:
       # required in order to allow the reusable called workflow to push to
       # GitHub Container Registry
       packages: write
-    uses: ccao-data/actions/.github/workflows/build-and-run-batch-job.yaml@jeancochrane/support-container-env-vars-in-batch-jobs
+    uses: ccao-data/actions/.github/workflows/build-and-run-batch-job.yaml@main
     with:
-      ref: jeancochrane/support-container-env-vars-in-batch-jobs
       vcpu: "16.0"
       memory: "65536"
       role-duration-seconds: 14400  # Worst-case time for a full model run

--- a/.github/workflows/build-and-run-model.yaml
+++ b/.github/workflows/build-and-run-model.yaml
@@ -27,11 +27,14 @@ jobs:
       # required in order to allow the reusable called workflow to push to
       # GitHub Container Registry
       packages: write
-    uses: ccao-data/actions/.github/workflows/build-and-run-batch-job.yaml@main
+    uses: ccao-data/actions/.github/workflows/build-and-run-batch-job.yaml@jeancochrane/support-container-env-vars-in-batch-jobs
     with:
+      ref: jeancochrane/support-container-env-vars-in-batch-jobs
       vcpu: "16.0"
       memory: "65536"
       role-duration-seconds: 14400  # Worst-case time for a full model run
     secrets:
       AWS_IAM_ROLE_TO_ASSUME_ARN: ${{ secrets.AWS_IAM_ROLE_TO_ASSUME_ARN }}
       AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+      CONTAINER_ENV_VARS: |
+        AWS_SNS_ARN_MODEL_STATUS=${{ secrets.AWS_SNS_ARN_MODEL_STATUS }}


### PR DESCRIPTION
This PR is the twin of https://github.com/ccao-data/model-res-avm/pull/64, fixing a bug to ensure that the model pipeline sends SNS status notifications.

Link to successful workflow run: https://github.com/ccao-data/model-condo-avm/actions/runs/7062881392/job/19227930519?pr=14 Check your email to confirm that the SNS notification was sent properly.