### PR TITLE
Remove zero and `NA` value  parcels from iasWorld export

### DIFF
--- a/pipeline/07-export.R
+++ b/pipeline/07-export.R
@@ -566,7 +566,7 @@ for (town in unique(upload_data_prepped$township_code)) {
   message("Now processing: ", town_convert(town))
 
   upload_data_fil <- upload_data_prepped %>%
-    filter(township_code == town, MV != 0) %>%
+    filter(township_code == town, MV > 0, !is.na(MV)) %>%
     select(-township_code)
 
   readr::write_csv(

--- a/pipeline/07-export.R
+++ b/pipeline/07-export.R
@@ -566,7 +566,7 @@ for (town in unique(upload_data_prepped$township_code)) {
   message("Now processing: ", town_convert(town))
 
   upload_data_fil <- upload_data_prepped %>%
-    filter(township_code == town) %>%
+    filter(township_code == town, MV != 0) %>%
     select(-township_code)
 
   readr::write_csv(


### PR DESCRIPTION
Buildings with no livable units will have values of zero assigned to all of their parcels. We don't want to export these zero values to iasWorld. This PR removes those parcels from the iasWorld export.