### PR TITLE
Remove common area specific valuation

### DIFF
--- a/params.yaml
+++ b/params.yaml
@@ -337,10 +337,6 @@ model:
 
 # Parameters used in the assess stage to finalize the intial model predictions
 pv:
-  # For nonlivable units, anything below this value gets the same value as the
-  # prior year
-  nonlivable_threshold: 1000
-
   # Cap the proportion of the PIN's total value dedicated to land. This is
   # necessary since sometimes the model provides low predictions relative to the
   # land rates created by Valuations

--- a/pipeline/02-assess.R
+++ b/pipeline/02-assess.R
@@ -105,17 +105,7 @@ assessment_data_bldg <- assessment_data_pred %>%
       na.rm = TRUE
     ),
     pred_pin_final_fmv = bldg_total_value_livable *
-      (adj_pro_rate / bldg_total_proration_rate_livable),
-    # For certain units (common areas), we want to have a consistent low value
-    # across time (usually $10)
-    pred_pin_final_fmv = case_when(
-      meta_modeling_group == "NONLIVABLE" &
-        (meta_mailed_tot * 10) <= params$pv$nonlivable_threshold ~
-        meta_mailed_tot * 10,
-      meta_modeling_group == "NONLIVABLE" &
-        is.na(meta_mailed_tot) ~ 10,
-      TRUE ~ pred_pin_final_fmv
-    )
+      (adj_pro_rate / bldg_total_proration_rate_livable)
   ) %>%
   ungroup()
 

--- a/pipeline/05-finalize.R
+++ b/pipeline/05-finalize.R
@@ -97,7 +97,6 @@ metadata <- tibble::tibble(
   cv_no_improve = params$cv$no_improve,
   cv_split_prop = params$cv$split_prop,
   cv_best_metric = params$cv$best_metric,
-  pv_nonlivable_threshold = params$pv$nonlivable_threshold,
   pv_land_pct_of_total_cap = params$pv$land_pct_of_total_cap,
   pv_round_break = list(params$pv$round_break),
   pv_round_to_nearest = list(params$pv$round_to_nearest),

--- a/pipeline/07-export.R
+++ b/pipeline/07-export.R
@@ -110,11 +110,6 @@ assessment_pin_prepped <- assessment_pin %>%
       ", ", loc_property_zip
     ),
     meta_pin10 = str_sub(meta_pin, 1, 10),
-    flag_common_area = replace_na(
-      as.logical(as.numeric(flag_prior_near_to_pred_unchanged)) &
-        prior_near_tot <= params$pv$nonlivable_threshold,
-      0
-    ),
     across(
       ends_with("added_later") & where(is.logical),
       ~ as.numeric(.x)


### PR DESCRIPTION
Valuations believes we are likely perpetuating inaccurate common area designations for condo parcels and that common areas should not be designated as condo parcels anyhow; we should completely ignore common area as a category when valuing condos in the pipeline.