### PR TITLE
Switch from multisession parallelization to multicore in `evaluate` stage

### DIFF
--- a/pipeline/03-evaluate.R
+++ b/pipeline/03-evaluate.R
@@ -12,8 +12,17 @@ tictoc::tic("Evaluate")
 # Load libraries, helpers, and recipes from files
 purrr::walk(list.files("R/", "\\.R$", full.names = TRUE), source)
 
-# Enable parallel backend for generating stats more quickly
-plan(multisession, workers = num_threads)
+# Enable parallel backend for generating stats faster.
+# In the past we used the 'multisession' parallelization strategy, but this
+# strategy exhibits diminishing returns (and eventually worse performance) past
+# 5 workers on the server, and it's not particularly fast either (~10 mins to
+# complete this stage). The 'multicore' strategy has a higher risk of hogging
+# server resources for the duration of execution, but it executes much faster
+# than the multisession strategy (~80 seconds to complete this stage), so
+# ultimately we think it's worth the risk; plus, we only use half the available
+# cores in order to ensure we don't block execution of other important tasks on
+# the server.
+plan(multicore, workers = ceiling(num_threads / 2))
 
 # Renaming dictionary for input columns. We want the actual value of the column
 # to become geography_id and the NAME of the column to become geography_name

--- a/pipeline/03-evaluate.R
+++ b/pipeline/03-evaluate.R
@@ -13,16 +13,13 @@ tictoc::tic("Evaluate")
 purrr::walk(list.files("R/", "\\.R$", full.names = TRUE), source)
 
 # Enable parallel backend for generating stats faster.
-# In the past we used the 'multisession' parallelization strategy, but this
-# strategy exhibits diminishing returns (and eventually worse performance) past
-# 5 workers on the server, and it's not particularly fast either (~10 mins to
-# complete this stage). The 'multicore' strategy has a higher risk of hogging
-# server resources for the duration of execution, but it executes much faster
-# than the multisession strategy (~80 seconds to complete this stage), so
-# ultimately we think it's worth the risk; plus, we only use half the available
-# cores in order to ensure we don't block execution of other important tasks on
-# the server.
-plan(multicore, workers = ceiling(num_threads / 2))
+if (supportsMulticore()) {
+  # Limit to half the available cores to avoid hogging resources
+  plan(multicore, workers = ceiling(num_threads / 2))
+} else {
+  # Multisession performance begins to degrade beyond 5 workers
+  plan(multisession, workers = 5)
+}
 
 # Renaming dictionary for input columns. We want the actual value of the column
 # to become geography_id and the NAME of the column to become geography_name


### PR DESCRIPTION
This PR updates the `evaluate` stage of the pipeline to switch from the [multisession](https://future.futureverse.org/reference/multisession.html) parallelization strategy to [multicore](https://future.futureverse.org/reference/multicore.html). This change is intended to fix the behavior we've been seeing on the server whereby the `evaluate` stage takes so long to complete that it makes development difficult.

I'm not sure why this behavior appears to be different from last year, but my experiments with trying different numbers of workers using the "multisession" strategy on a minimal reprex revealed that execution begins to slow down when the number of workers increases past 5 (minimum runtime ~10 minutes). There must be some sort of overhead that the background R processes incur, but I couldn't find anything in the docs explaining it. Switching to the "multicore" strategy resolves this problem of diminishing returns, but incurs the risk of using more memory (due to forked process isolation) and more CPU resources (due to execution using logical cores rather than threads). In order to mitigate this risk, we reduce the number of workers to half the available logical cores on the machine that runs the pipeline. With 16 cores on the server, this causes the `evaluate` stage to execute fast enough (~80 seconds) that I'm not too worried about hogging resources.

Note that this change also decreases the execution time for this stage on Batch from [200s](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/%2Faws%2Fbatch%2Fjob/log-events/ccao-data-model-condo-avm%2Fdefault%2F5f30ee5f38b544f4a8a1a172639fa32e) to [60s](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/%2Faws%2Fbatch%2Fjob/log-events/z_ci_jeancochrane-switch-from-multisession-paralellization-to-multicore_ccao-data-model-condo-avm%2Fdefault%2F9f069a09bfa549eca8ab44ecbd0f056c).