### PR TITLE
Standardize outlier reason names

### DIFF
--- a/pipeline/00-ingest.R
+++ b/pipeline/00-ingest.R
@@ -287,9 +287,9 @@ training_data_fil <- training_data_klg %>%
     # due to https://github.com/ccao-data/data-architecture/pull/334
     sv_outlier_type = case_when(
       meta_sale_price < 40000 & sv_added_later ~
-        "Low price (raw)",
+        "Low price",
       meta_sale_price > 1500000 & sv_added_later ~
-        "High price (raw)",
+        "High price",
       TRUE ~ sv_outlier_type
     ),
     sv_is_outlier = ifelse(


### PR DESCRIPTION
This PR [standardizes](https://github.com/ccao-data/model-sales-val/blob/a60618004e85dd53a5e0decec481fa797ec680a0/glue/sales_val_flagging.py#L240-L246) the manually assigned outlier names from the `00-ingest.R` stage. The existing method was an artifact from the older sales val specifications.

Closes #59 