### PR TITLE
Lint YAML files and suppress warnings in the evaluate stage

### DIFF
--- a/.github/workflows/build-and-run-model.yaml
+++ b/.github/workflows/build-and-run-model.yaml
@@ -18,12 +18,12 @@ on:
         type: choice
         description: Run type or purpose
         options:
-        - junk
-        - rejected
-        - test
-        - baseline
-        - candidate
-        - final
+          - junk
+          - rejected
+          - test
+          - baseline
+          - candidate
+          - final
         default: test
         required: true
       run_note:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,28 +1,28 @@
 # All available hooks: https://pre-commit.com/hooks.html
 # R specific hooks: https://github.com/lorenzwalthert/precommit
 repos:
--   repo: https://github.com/lorenzwalthert/precommit
+  - repo: https://github.com/lorenzwalthert/precommit
     rev: v0.4.2
     hooks:
-    -   id: style-files
+      - id: style-files
         args: [--style_pkg=styler, --style_fun=tidyverse_style]
         require_serial: true
-    -   id: lintr
-    -   id: readme-rmd-rendered
+      - id: lintr
+      - id: readme-rmd-rendered
         exclude: reports/README.md
-    -   id: parsable-R
-    -   id: no-browser-statement
-    -   id: no-debug-statement
--   repo: https://github.com/pre-commit/pre-commit-hooks
+      - id: parsable-R
+      - id: no-browser-statement
+      - id: no-debug-statement
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
     hooks:
-    -   id: check-added-large-files
+      - id: check-added-large-files
         args: ['--maxkb=200']
-    -   id: mixed-line-ending
+      - id: mixed-line-ending
         args: ['--fix=no']
--   repo: local
+  - repo: local
     hooks:
-    -   id: forbid-to-commit
+      - id: forbid-to-commit
         name: Don't commit common R artifacts
         entry: Cannot commit .Rhistory, .RData, .Rds or .rds.
         language: fail

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -4,14 +4,14 @@ stages:
     desc: >
       Ingest training and assessment data from Athena + generate condo strata
     params:
-    - assessment
-    - input
+      - assessment
+      - input
     outs:
-    - input/assessment_data.parquet
-    - input/char_data.parquet
-    - input/condo_strata_data.parquet
-    - input/land_nbhd_rate_data.parquet
-    - input/training_data.parquet
+      - input/assessment_data.parquet
+      - input/char_data.parquet
+      - input/condo_strata_data.parquet
+      - input/land_nbhd_rate_data.parquet
+      - input/training_data.parquet
     frozen: true
 
   train:
@@ -20,33 +20,33 @@ stages:
       Train a LightGBM model with cross-validation. Generate model objects,
       data recipes, and predictions on the test set (most recent 10% of sales)
     deps:
-    - input/training_data.parquet
+      - input/training_data.parquet
     params:
-    - cv
-    - model.engine
-    - model.hyperparameter
-    - model.objective
-    - model.parameter
-    - model.predictor
-    - model.seed
-    - model.verbose
-    - ratio_study
-    - toggle.cv_enable
+      - cv
+      - model.engine
+      - model.hyperparameter
+      - model.objective
+      - model.parameter
+      - model.predictor
+      - model.seed
+      - model.verbose
+      - ratio_study
+      - toggle.cv_enable
     outs:
-    - output/intermediate/timing/model_timing_train.parquet:
-        cache: false
-    - output/parameter_final/model_parameter_final.parquet:
-        cache: false
-    - output/parameter_range/model_parameter_range.parquet:
-        cache: false
-    - output/parameter_search/model_parameter_search.parquet:
-        cache: false
-    - output/test_card/model_test_card.parquet:
-        cache: false
-    - output/workflow/fit/model_workflow_fit.zip:
-        cache: false
-    - output/workflow/recipe/model_workflow_recipe.rds:
-        cache: false
+      - output/intermediate/timing/model_timing_train.parquet:
+          cache: false
+      - output/parameter_final/model_parameter_final.parquet:
+          cache: false
+      - output/parameter_range/model_parameter_range.parquet:
+          cache: false
+      - output/parameter_search/model_parameter_search.parquet:
+          cache: false
+      - output/test_card/model_test_card.parquet:
+          cache: false
+      - output/workflow/fit/model_workflow_fit.zip:
+          cache: false
+      - output/workflow/recipe/model_workflow_recipe.rds:
+          cache: false
 
   assess:
     cmd: Rscript pipeline/02-assess.R
@@ -55,24 +55,24 @@ stages:
       County. Also generate flags, calculate land values, and make any
       post-modeling changes
     deps:
-    - input/assessment_data.parquet
-    - input/condo_strata_data.parquet
-    - input/land_nbhd_rate_data.parquet
-    - input/training_data.parquet
-    - output/workflow/fit/model_workflow_fit.zip
-    - output/workflow/recipe/model_workflow_recipe.rds
+      - input/assessment_data.parquet
+      - input/condo_strata_data.parquet
+      - input/land_nbhd_rate_data.parquet
+      - input/training_data.parquet
+      - output/workflow/fit/model_workflow_fit.zip
+      - output/workflow/recipe/model_workflow_recipe.rds
     params:
-    - assessment
-    - model.predictor.all
-    - pv
-    - ratio_study
+      - assessment
+      - model.predictor.all
+      - pv
+      - ratio_study
     outs:
-    - output/assessment_card/model_assessment_card.parquet:
-        cache: false
-    - output/assessment_pin/model_assessment_pin.parquet:
-        cache: false
-    - output/intermediate/timing/model_timing_assess.parquet:
-        cache: false
+      - output/assessment_card/model_assessment_card.parquet:
+          cache: false
+      - output/assessment_pin/model_assessment_pin.parquet:
+          cache: false
+      - output/intermediate/timing/model_timing_assess.parquet:
+          cache: false
 
   evaluate:
     cmd: Rscript pipeline/03-evaluate.R
@@ -82,22 +82,22 @@ stages:
         2. An assessor-specific ratio study comparing estimated assessments to
            the previous year's sales
     deps:
-    - output/assessment_pin/model_assessment_pin.parquet
-    - output/test_card/model_test_card.parquet
+      - output/assessment_pin/model_assessment_pin.parquet
+      - output/test_card/model_test_card.parquet
     params:
-    - assessment
-    - ratio_study
+      - assessment
+      - ratio_study
     outs:
-    - output/performance/model_performance_test.parquet:
-        cache: false
-    - output/performance_quantile/model_performance_quantile_test.parquet:
-        cache: false
-    - output/performance/model_performance_assessment.parquet:
-        cache: false
-    - output/performance_quantile/model_performance_quantile_assessment.parquet:
-        cache: false
-    - output/intermediate/timing/model_timing_evaluate.parquet:
-        cache: false
+      - output/performance/model_performance_test.parquet:
+          cache: false
+      - output/performance_quantile/model_performance_quantile_test.parquet:
+          cache: false
+      - output/performance/model_performance_assessment.parquet:
+          cache: false
+      - output/performance_quantile/model_performance_quantile_assessment.parquet:
+          cache: false
+      - output/intermediate/timing/model_timing_evaluate.parquet:
+          cache: false
 
   interpret:
     cmd: Rscript pipeline/04-interpret.R
@@ -105,19 +105,19 @@ stages:
       Generate SHAP values for each card and feature as well as feature
       importance metrics for each feature
     deps:
-    - input/assessment_data.parquet
-    - output/workflow/fit/model_workflow_fit.zip
-    - output/workflow/recipe/model_workflow_recipe.rds
+      - input/assessment_data.parquet
+      - output/workflow/fit/model_workflow_fit.zip
+      - output/workflow/recipe/model_workflow_recipe.rds
     params:
-    - toggle.shap_enable
-    - model.predictor.all
+      - toggle.shap_enable
+      - model.predictor.all
     outs:
-    - output/shap/model_shap.parquet:
-        cache: false
-    - output/feature_importance/model_feature_importance.parquet:
-        cache: false
-    - output/intermediate/timing/model_timing_interpret.parquet:
-        cache: false
+      - output/shap/model_shap.parquet:
+          cache: false
+      - output/feature_importance/model_feature_importance.parquet:
+          cache: false
+      - output/intermediate/timing/model_timing_interpret.parquet:
+          cache: false
 
   finalize:
     cmd: Rscript pipeline/05-finalize.R
@@ -125,27 +125,27 @@ stages:
       Save run timings and run metadata to disk and render a performance report
       using Quarto.
     deps:
-    - output/intermediate/timing/model_timing_train.parquet
-    - output/intermediate/timing/model_timing_assess.parquet
-    - output/intermediate/timing/model_timing_evaluate.parquet
-    - output/intermediate/timing/model_timing_interpret.parquet
+      - output/intermediate/timing/model_timing_train.parquet
+      - output/intermediate/timing/model_timing_assess.parquet
+      - output/intermediate/timing/model_timing_evaluate.parquet
+      - output/intermediate/timing/model_timing_interpret.parquet
     params:
-    - run_note
-    - toggle
-    - input
-    - cv
-    - model
-    - pv
-    - ratio_study
+      - run_note
+      - toggle
+      - input
+      - cv
+      - model
+      - pv
+      - ratio_study
     outs:
-    - output/intermediate/timing/model_timing_finalize.parquet:
-        cache: false
-    - output/timing/model_timing.parquet:
-        cache: false
-    - output/metadata/model_metadata.parquet:
-        cache: false
-    - reports/performance/performance.html:
-        cache: false
+      - output/intermediate/timing/model_timing_finalize.parquet:
+          cache: false
+      - output/timing/model_timing.parquet:
+          cache: false
+      - output/metadata/model_metadata.parquet:
+          cache: false
+      - reports/performance/performance.html:
+          cache: false
 
   upload:
     cmd: Rscript pipeline/06-upload.R
@@ -155,23 +155,23 @@ stages:
       outputs prior to upload and attach a unique run ID. This step requires
       access to the CCAO Data AWS account, and so is assumed to be internal-only
     deps:
-    - output/parameter_final/model_parameter_final.parquet
-    - output/parameter_range/model_parameter_range.parquet
-    - output/parameter_search/model_parameter_search.parquet
-    - output/workflow/fit/model_workflow_fit.zip
-    - output/workflow/recipe/model_workflow_recipe.rds
-    - output/test_card/model_test_card.parquet
-    - output/assessment_card/model_assessment_card.parquet
-    - output/assessment_pin/model_assessment_pin.parquet
-    - output/performance/model_performance_test.parquet
-    - output/performance_quantile/model_performance_quantile_test.parquet
-    - output/performance/model_performance_assessment.parquet
-    - output/performance_quantile/model_performance_quantile_assessment.parquet
-    - output/shap/model_shap.parquet
-    - output/feature_importance/model_feature_importance.parquet
-    - output/metadata/model_metadata.parquet
-    - output/timing/model_timing.parquet
-    - reports/performance/performance.html
+      - output/parameter_final/model_parameter_final.parquet
+      - output/parameter_range/model_parameter_range.parquet
+      - output/parameter_search/model_parameter_search.parquet
+      - output/workflow/fit/model_workflow_fit.zip
+      - output/workflow/recipe/model_workflow_recipe.rds
+      - output/test_card/model_test_card.parquet
+      - output/assessment_card/model_assessment_card.parquet
+      - output/assessment_pin/model_assessment_pin.parquet
+      - output/performance/model_performance_test.parquet
+      - output/performance_quantile/model_performance_quantile_test.parquet
+      - output/performance/model_performance_assessment.parquet
+      - output/performance_quantile/model_performance_quantile_assessment.parquet
+      - output/shap/model_shap.parquet
+      - output/feature_importance/model_feature_importance.parquet
+      - output/metadata/model_metadata.parquet
+      - output/timing/model_timing.parquet
+      - reports/performance/performance.html
 
   export:
     cmd: Rscript pipeline/07-export.R
@@ -180,9 +180,9 @@ stages:
       run. NOT automatically run since it is typically only run once. Manually
       run once a model is selected
     params:
-    - assessment.year
-    - input.min_sale_year
-    - input.max_sale_year
-    - ratio_study
-    - export
+      - assessment.year
+      - input.min_sale_year
+      - input.max_sale_year
+      - ratio_study
+      - export
     frozen: true

--- a/params.yaml
+++ b/params.yaml
@@ -22,15 +22,15 @@ run_note: >
 toggle:
   # Should the train stage run full cross-validation? Otherwise, the model
   # will be trained with the default hyperparameters specified below
-  cv_enable: FALSE
+  cv_enable: false
 
   # Should SHAP values be calculated for this run in the interpret stage? Can be
   # desirable to save time when testing many models
-  shap_enable: FALSE
+  shap_enable: false
 
   # Upload all modeling artifacts and results to S3 in the upload stage. Set
-  # to FALSE if you are not a CCAO employee
-  upload_enable: TRUE
+  # to false if you are not a CCAO employee
+  upload_enable: true
 
 
 # Data/Ingest ------------------------------------------------------------------
@@ -134,8 +134,8 @@ model:
   # Parameters related to model determinism. Current settings should force
   # the same output every time if the same hyperparameters are used
   seed: 2024
-  deterministic: TRUE
-  force_row_wise: TRUE
+  deterministic: true
+  force_row_wise: true
 
   # Model verbosity: < 0: Fatal, = 0: Error (Warning), = 1: Info, > 1: Debug
   verbose: -1
@@ -267,9 +267,9 @@ model:
     validation_metric: "rmse"
 
     # Custom parameters added by the CCAO's lightsnip wrapper package. Setting
-    # to TRUE will set max_depth = floor(log2(num_leaves)) + add_to_linked_depth
+    # to true will set max_depth = floor(log2(num_leaves)) + add_to_linked_depth
     # This is to prevent tune_bayes from exploring useless parameter space
-    link_max_depth: TRUE
+    link_max_depth: true
 
     # During CV, the number of iterations to go without improvement before
     # stopping training. Early stopping is deactivated when NULL
@@ -317,19 +317,19 @@ model:
       # number actual used is reported in the lgbm_final_params object in the
       # train stage and parameter_final table in the run outputs/Athena
       num_iterations: [100, 2500]
-      learning_rate: [-3.0, -0.4] # 10 ^ X
+      learning_rate: [-3.0, -0.4]  # 10 ^ X
       max_bin: [50, 512]
       num_leaves: [32, 2048]
       add_to_linked_depth: [1, 7]
       feature_fraction: [0.3, 0.7]
-      min_gain_to_split: [-3.0, 4.0] # 10 ^ X
+      min_gain_to_split: [-3.0, 4.0]  # 10 ^ X
       min_data_in_leaf: [2, 400]
       max_cat_threshold: [10, 250]
       min_data_per_group: [2, 400]
       cat_smooth: [10.0, 200.0]
-      cat_l2: [-3, 2] # 10 ^ X
-      lambda_l1: [-3, 2] # 10 ^ X
-      lambda_l2: [-3, 2] # 10 ^ X
+      cat_l2: [-3, 2]  # 10 ^ X
+      lambda_l1: [-3, 2]  # 10 ^ X
+      lambda_l2: [-3, 2]  # 10 ^ X
       neighbors: [5, 40]
 
 

--- a/pipeline/00-ingest.R
+++ b/pipeline/00-ingest.R
@@ -20,7 +20,10 @@ suppressPackageStartupMessages({
 })
 
 # Establish Athena connection
-AWS_ATHENA_CONN_NOCTUA <- dbConnect(noctua::athena())
+AWS_ATHENA_CONN_NOCTUA <- dbConnect(
+  noctua::athena(),
+  rstudio_conn_tab = FALSE
+)
 
 
 

--- a/pipeline/03-evaluate.R
+++ b/pipeline/03-evaluate.R
@@ -266,7 +266,7 @@ gen_agg_stats_quantile <- function(data, truth, estimate,
     summarize(
       num_sale = sum(!is.na({{ truth }})),
       median_ratio = median(({{ estimate }} / {{ truth }}), na.rm = TRUE),
-        # Suppress warnings resulting from groups of size 0 or 1
+      # Suppress warnings resulting from groups of size 0 or 1
       lower_bound = suppressWarnings(min({{ truth }}, na.rm = TRUE)),
       upper_bound = suppressWarnings(max({{ truth }}, na.rm = TRUE)),
       prior_near_yoy_pct_chg_median = median(

--- a/pipeline/03-evaluate.R
+++ b/pipeline/03-evaluate.R
@@ -110,7 +110,9 @@ gen_agg_stats <- function(data, truth, estimate, bldg_sqft,
   )
   ys_fns_list <- list(
     rmse        = rmse_vec,
-    r_squared   = rsq_vec,
+    # Necessary because sometimes all sales in a group will be the same,
+    # resulting in a std. dev. of 0 (and thus a warning)
+    r_squared   = \(y, x) suppressWarnings(rsq_vec(y, x)),
     mae         = mae_vec,
     mpe         = mpe_vec,
     mape        = mape_vec,
@@ -168,13 +170,13 @@ gen_agg_stats <- function(data, truth, estimate, bldg_sqft,
 
       # Yardstick (ML-specific) performance stats
       ys_lst = ys_fns_list %>%
-        map(., \(f) exec(f, {{ truth }}, {{ estimate }})) %>%
+        map(., \(f) gte_n({{ truth }}, 2, exec(f, {{ truth }}, {{ estimate }}), NA_real_)) %>% # nolint
         list(),
 
       # Summary stats of sale price and sale price per sqft
       sum_sale_lst = sum_fns_list %>%
         set_names(paste0("sale_fmv_", names(.))) %>%
-        map(., \(f) exec(f, {{ truth }})) %>%
+        map(., \(f) suppressWarnings(exec(f, {{ truth }}))) %>%
         list(),
       sum_sale_sf_lst = sum_sqft_fns_list %>%
         set_names(paste0("sale_fmv_per_sqft_", names(.))) %>%
@@ -185,15 +187,15 @@ gen_agg_stats <- function(data, truth, estimate, bldg_sqft,
       prior_far_num_missing = sum(is.na({{ rsf_col }})),
       sum_rsf_lst = sum_fns_list %>%
         set_names(paste0("prior_far_fmv_", names(.))) %>%
-        map(., \(f) exec(f, {{ rsf_col }})) %>%
+        map(., \(f) suppressWarnings(exec(f, {{ rsf_col }}))) %>%
         list(),
       sum_rsf_sf_lst = sum_sqft_fns_list %>%
         set_names(paste0("prior_far_fmv_per_sqft_", names(.))) %>%
-        map(., \(f) exec(f, {{ rsf_col }}, {{ bldg_sqft }})) %>%
+        map(., \(f) suppressWarnings(exec(f, {{ rsf_col }}, {{ bldg_sqft }}))) %>% # nolint
         list(),
       yoy_rsf_lst = yoy_fns_list %>%
         set_names(paste0("prior_far_yoy_pct_chg_", names(.))) %>%
-        map(., \(f) exec(f, {{ estimate }}, {{ rsf_col }})) %>%
+        map(., \(f) suppressWarnings(exec(f, {{ estimate }}, {{ rsf_col }}))) %>% # nolint
         list(),
       prior_near_num_missing = sum(is.na({{ rsn_col }})),
       sum_rsn_lst = sum_fns_list %>%
@@ -264,8 +266,9 @@ gen_agg_stats_quantile <- function(data, truth, estimate,
     summarize(
       num_sale = sum(!is.na({{ truth }})),
       median_ratio = median(({{ estimate }} / {{ truth }}), na.rm = TRUE),
-      lower_bound = min({{ truth }}, na.rm = TRUE),
-      upper_bound = max({{ truth }}, na.rm = TRUE),
+        # Suppress warnings resulting from groups of size 0 or 1
+      lower_bound = suppressWarnings(min({{ truth }}, na.rm = TRUE)),
+      upper_bound = suppressWarnings(max({{ truth }}, na.rm = TRUE)),
       prior_near_yoy_pct_chg_median = median(
         ({{ estimate }} - {{ rsn_col }}) / {{ rsn_col }},
         na.rm = TRUE


### PR DESCRIPTION
This PR is the condo model version of https://github.com/ccao-data/model-res-avm/pull/278, making a few small aesthetic tweaks:

* Linting all YAML files
* Suppressing certain warnings in the evaluate stage

We don't need to duplicate the functional changes that we made in https://github.com/ccao-data/model-res-avm/pull/278 since the condo model:

* Never had a `_quarto.yml` file
* Never used land site rates

Output of `yamllint .` after these changes:

```
./.pre-commit-config.yaml
  3:1       warning  missing document start "---"  (document-start)

./params.yaml
  14:1      warning  missing document start "---"  (document-start)

./dvc.yaml
  1:1       warning  missing document start "---"  (document-start)

./.github/workflows/build-and-run-model.yaml
  10:1      warning  missing document start "---"  (document-start)
  12:1      warning  truthy value should be one of [false, true]  (truthy)

./.github/workflows/pre-commit.yaml
  1:1       warning  missing document start "---"  (document-start)
  1:1       warning  truthy value should be one of [false, true]  (truthy)

./renv/library/R-4.3/x86_64-pc-linux-gnu/rmarkdown/rmarkdown/templates/html_vignette/template.yaml
  1:1       warning  missing document start "---"  (document-start)

./renv/library/R-4.3/x86_64-pc-linux-gnu/rmarkdown/rmarkdown/templates/github_document/template.yaml
  1:1       warning  missing document start "---"  (document-start)

./renv/library/R-4.3/x86_64-pc-linux-gnu/rmarkdown/rmd/site/_site.yml
  1:1       warning  missing document start "---"  (document-start)

./renv/library/R-4.3/x86_64-pc-linux-gnu/bslib/rmarkdown/templates/real-time/template.yaml
  1:1       warning  missing document start "---"  (document-start)

./renv/library/R-4.3/x86_64-pc-linux-gnu/bslib/rmarkdown/templates/legacy/template.yaml
  1:1       warning  missing document start "---"  (document-start)

./renv/library/R-4.3/x86_64-pc-linux-gnu/bslib/rmarkdown/templates/new/template.yaml
  1:1       warning  missing document start "---"  (document-start)

./renv/library/R-4.3/x86_64-pc-linux-gnu/tidymodels/rmarkdown/templates/model-analysis/template.yaml
  1:1       warning  missing document start "---"  (document-start)
  4:13      warning  truthy value should be one of [false, true]  (truthy)
```

We didn't resolve these remaining warnings in the res model, so I'm not doing so here either.
