### PR TITLE
Consider assessment year branches to be main branches in GitHub workflows

### DIFF
--- a/.github/workflows/build-and-run-model.yaml
+++ b/.github/workflows/build-and-run-model.yaml
@@ -46,7 +46,7 @@ on:
         default: false
         required: true
   push:
-    branches: [master]
+    branches: [master, "*-assessment-year"]
 
 jobs:
   build-and-run-model:

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,7 +1,7 @@
 on:
   pull_request:
   push:
-    branches: [main, master]
+    branches: [main, master, "*-assessment-year"]
 
 name: pre-commit
 


### PR DESCRIPTION
This PR creates parity with https://github.com/ccao-data/model-res-avm/pull/286.