### PR TITLE
Add test for NA or NULL values

### DIFF
--- a/reports/performance/_outliers.qmd
+++ b/reports/performance/_outliers.qmd
@@ -483,6 +483,7 @@ outlier_decile_breakout(training_data, 1)
 ::: panel-tabset
 
 ### Card Level
+
 ```{r _outliers_output_errors_card}
 assessment_card %>%
   summarize(
@@ -490,19 +491,4 @@ assessment_card %>%
     "Negative Card FMV" = sum(pred_card_initial_fmv < 0, na.rm = TRUE)
   ) %>%
   datatable()
-```
-
-### Pin Level
-```{r _outliers_output_errors_pin}
-assessment_pin %>%
-  summarize(
-    "NA Pin FMV" = sum(is.na(pred_pin_final_fmv)),
-    "Negative Pin FMV" = sum(pred_pin_final_fmv < 0, na.rm = TRUE),
-    "NA Building FMV" = sum(is.na(pred_pin_final_fmv_bldg)),
-    "Negative Building FMV" = sum(pred_pin_final_fmv_bldg < 0, na.rm = TRUE),
-    "NA Land FMV" = sum(is.na(pred_pin_final_fmv_land)),
-    "Negative Land FMV" = sum(pred_pin_final_fmv_land < 0, na.rm = TRUE)
-  ) %>%
-  datatable()
-```
 :::

--- a/reports/performance/_outliers.qmd
+++ b/reports/performance/_outliers.qmd
@@ -491,4 +491,21 @@ assessment_card %>%
     "Negative Card FMV" = sum(pred_card_initial_fmv < 0, na.rm = TRUE)
   ) %>%
   datatable()
+```
+
+### Pin Level
+
+```{r _outliers_output_errors_pin}
+assessment_pin %>%
+  summarize(
+    "NA Pin FMV" = sum(is.na(pred_pin_final_fmv)),
+    "Negative Pin FMV" = sum(pred_pin_final_fmv < 0, na.rm = TRUE),
+    "NA Building FMV" = sum(is.na(pred_pin_final_fmv_bldg)),
+    "Negative Building FMV" = sum(pred_pin_final_fmv_bldg < 0, na.rm = TRUE),
+    "NA Land FMV" = sum(is.na(pred_pin_final_fmv_land)),
+    "Negative Land FMV" = sum(pred_pin_final_fmv_land < 0, na.rm = TRUE)
+  ) %>%
+  datatable()
+```
+
 :::

--- a/reports/performance/_outliers.qmd
+++ b/reports/performance/_outliers.qmd
@@ -477,3 +477,32 @@ outlier_decile_breakout(training_data, 1)
 ```
 
 :::
+
+## Possible Output Errors
+
+::: panel-tabset
+
+### Card Level
+```{r _outliers_output_errors_card}
+assessment_card %>%
+  summarize(
+    "NA Card FMV" = sum(is.na(pred_card_initial_fmv)),
+    "Negative Card FMV" = sum(pred_card_initial_fmv < 0, na.rm = TRUE)
+  ) %>%
+  datatable()
+```
+
+### Pin Level
+```{r _outliers_output_errors_pin}
+assessment_pin %>%
+  summarize(
+    "NA Pin FMV" = sum(is.na(pred_pin_final_fmv)),
+    "Negative Pin FMV" = sum(pred_pin_final_fmv < 0, na.rm = TRUE),
+    "NA Building FMV" = sum(is.na(pred_pin_final_fmv_bldg)),
+    "Negative Building FMV" = sum(pred_pin_final_fmv_bldg < 0, na.rm = TRUE),
+    "NA Land FMV" = sum(is.na(pred_pin_final_fmv_land)),
+    "Negative Land FMV" = sum(pred_pin_final_fmv_land < 0, na.rm = TRUE)
+  ) %>%
+  datatable()
+```
+:::


### PR DESCRIPTION
As found in https://github.com/ccao-data/model-condo-avm/pull/78, NULL and NA values are often present in the Condo Pipeline. This provides counts for those values in the outliers section. 