### PR TITLE
Replace arrows with equal signs for outlier assignment

### DIFF
--- a/pipeline/00-ingest.R
+++ b/pipeline/00-ingest.R
@@ -20,7 +20,7 @@ suppressPackageStartupMessages({
 })
 
 # Adds arrow support to speed up ingest process
-noctua_options(unload = TRUE)
+noctua_options(unload = FALSE)
 
 # Establish Athena connection
 AWS_ATHENA_CONN_NOCTUA <- dbConnect(
@@ -328,17 +328,17 @@ training_data_clean <- training_data_fil %>%
     ),
     # Assign 'Non-livable area' to the first outlier reason and
     # set the other two outlier reason columns to NA
-    sv_outlier_reason1 <- ifelse(
+    sv_outlier_reason1 = ifelse(
       meta_modeling_group == "NONLIVABLE",
       "Non-livable area",
       sv_outlier_reason1
     ),
-    sv_outlier_reason2 <- ifelse(
+    sv_outlier_reason2 = ifelse(
       meta_modeling_group == "NONLIVABLE",
       NA_character_,
       sv_outlier_reason2
     ),
-    sv_outlier_reason3 <- ifelse(
+    sv_outlier_reason3 = ifelse(
       meta_modeling_group == "NONLIVABLE",
       NA_character_,
       sv_outlier_reason3

--- a/pipeline/00-ingest.R
+++ b/pipeline/00-ingest.R
@@ -20,7 +20,7 @@ suppressPackageStartupMessages({
 })
 
 # Adds arrow support to speed up ingest process
-noctua_options(unload = FALSE)
+noctua_options(unload = TRUE)
 
 # Establish Athena connection
 AWS_ATHENA_CONN_NOCTUA <- dbConnect(


### PR DESCRIPTION
The `sv_outlier_reason1` field was empty when we should have observed a non-livable description. For some reason we were using arrows instead of equal signs in the mutate assignment. We replace them and the outlier reason assignment is now fixed.