### PR TITLE
Remove year from desk review join

### DIFF
--- a/pipeline/07-export.R
+++ b/pipeline/07-export.R
@@ -91,7 +91,7 @@ message("Preparing data for Desk Review export")
 assessment_pin_prepped <- assessment_pin %>%
   left_join(
     assessment_pin_old,
-    by = c("year", "meta_pin")
+    by = c("meta_pin")
   ) %>%
   mutate(
     prior_near_land_rate = round(


### PR DESCRIPTION
When looking at https://github.com/ccao-data/model-condo-avm/pull/80, data from the final columns were returning as NA. This appears to be the issue of a join between condo runs where a previous iteration was done in the same year. Thus, the join could be on pin and year. Removing the year from the join results in valid outputs, and the dimensions of the join remain the same. However, I don't know if year was intended to be a part of the join for another reason. 