### PR TITLE
Remove PUMA filter on test set eval

### DIFF
--- a/params.yaml
+++ b/params.yaml
@@ -384,7 +384,6 @@ ratio_study:
     - "meta_nbhd_code"
     - "loc_tax_municipality_name"
     - "loc_ward_num"
-    - "loc_census_puma_geoid"
     - "loc_census_tract_geoid"
     - "loc_school_elementary_district_geoid"
     - "loc_school_secondary_district_geoid"

--- a/pipeline/03-evaluate.R
+++ b/pipeline/03-evaluate.R
@@ -47,10 +47,7 @@ message("Loading evaluation data")
 # Load the test results from the end of the train stage. This will be the most
 # recent 10% of sales and already includes predictions.
 test_data_card <- read_parquet(paths$output$test_card$local) %>%
-  filter(
-    !is.na(loc_census_puma_geoid),
-    meta_modeling_group == "CONDO"
-  )
+  filter(meta_modeling_group == "CONDO")
 
 # Load the assessment results from the previous stage. This will include every
 # residential PIN that needs a value.


### PR DESCRIPTION
Currently, 2024 PUMA geographies are all `NULL` since we haven't correctly attached them via the spatial join in `location.census`. This results in us dropping all 2024 sales from the test set evaluation.

We'll fix the data issue upstream via dbt builds, but in the meantime I think it's best to just remove this filter, since we almost never look at performance on the PUMA level.