### PR TITLE
Persist sv_run_id in the training data

### DIFF
--- a/pipeline/00-ingest.R
+++ b/pipeline/00-ingest.R
@@ -106,6 +106,7 @@ training_data <- dbGetQuery(
       sale.sv_outlier_reason1,
       sale.sv_outlier_reason2,
       sale.sv_outlier_reason3,
+      sale.sv_run_id,
       condo.*
   FROM model.vw_pin_condo_input condo
   INNER JOIN default.vw_pin_sale sale


### PR DESCRIPTION
Add `sv_run_id` in the training data ingest to be persisted. This could be useful if we need to backtrack which flag was used in a given final model. It also standardizes the model code, as [we are already doing this](https://github.com/ccao-data/model-res-avm/pull/202) in the res model 