### PR TITLE
Update DVC lockfile accounting for recent changes

### DIFF
--- a/dvc.lock
+++ b/dvc.lock
@@ -5,8 +5,8 @@ stages:
     deps:
     - path: pipeline/00-ingest.R
       hash: md5
-      md5: d908daab5b2c09f1a43ae52075dfb3cc
-      size: 25830
+      md5: a27acacb62349f1dcbcec564537fabb0
+      size: 26396
     params:
       params.yaml:
         assessment:
@@ -23,30 +23,33 @@ stages:
           building:
             weight_min: 0.1
             weight_max: 1.0
+          subset:
+            enable: false
+            fraction: 0.25
     outs:
     - path: input/assessment_data.parquet
       hash: md5
-      md5: 35b63193258294924ddab68280f786b1
-      size: 83105524
+      md5: 4e5420ce4b3474248fb5ac0447cd4945
+      size: 84282846
     - path: input/char_data.parquet
       hash: md5
-      md5: 2571d670ba03ccea9a34d6363f142296
-      size: 155406669
+      md5: 9d4c40b3bea65f0d8e7df43c6c0e213d
+      size: 158407178
     - path: input/land_nbhd_rate_data.parquet
       hash: md5
-      md5: b4cfaf3d4a35c250990752024a88f3bb
+      md5: cb489a55f638d90898a06976b2a9bda9
       size: 5709
     - path: input/training_data.parquet
       hash: md5
-      md5: 91f3e4af2047b1128708c9bd0b9625d5
-      size: 76219548
+      md5: 020cbfcfa2c04eb7acfdff72d80af4d7
+      size: 76245405
   train:
     cmd: Rscript pipeline/01-train.R
     deps:
     - path: input/training_data.parquet
       hash: md5
-      md5: 8e34ebaa488c6fbabe56c43dfec41667
-      size: 75827972
+      md5: 020cbfcfa2c04eb7acfdff72d80af4d7
+      size: 76245405
     - path: pipeline/01-train.R
       hash: md5
       md5: 7911bca87d5c7ea6c582cc33b5dfe82e
@@ -269,55 +272,55 @@ stages:
     outs:
     - path: output/intermediate/timing/model_timing_train.parquet
       hash: md5
-      md5: cf7bb7a8e3fee7b5b3adc3962b3ff972
-      size: 2494
+      md5: db35858510fea9dba6fc258f8c2e26f1
+      size: 2484
     - path: output/parameter_final/model_parameter_final.parquet
       hash: md5
       md5: 4e88c21fbd94c9f5a598dcdf670dab7c
       size: 6658
     - path: output/parameter_range/model_parameter_range.parquet
       hash: md5
-      md5: b378f8ae73167478032391c6cdd3bbad
+      md5: 50552341165b58ede24278a25b8d9952
       size: 501
     - path: output/parameter_search/model_parameter_search.parquet
       hash: md5
-      md5: b378f8ae73167478032391c6cdd3bbad
+      md5: 50552341165b58ede24278a25b8d9952
       size: 501
     - path: output/test_card/model_test_card.parquet
       hash: md5
-      md5: 1b24c9069bd5f98970de350345bbb095
-      size: 1301224
+      md5: 721ad01070e8be97c0c7d1b946fd1b5e
+      size: 1308629
     - path: output/workflow/fit/model_workflow_fit.zip
       hash: md5
-      md5: 8b5ee80cdc31308770dd865edb4c08ae
-      size: 2869594
+      md5: 89d07e1af56dccf16fb2ac6f40cc46a6
+      size: 2873661
     - path: output/workflow/recipe/model_workflow_recipe.rds
       hash: md5
-      md5: 6204871f9d831cf7db9fe62c3598fd20
-      size: 662614341
+      md5: d4ef5751a460e04a19f5d927500698ca
+      size: 665335235
   assess:
     cmd: Rscript pipeline/02-assess.R
     deps:
     - path: input/assessment_data.parquet
       hash: md5
-      md5: caaa3525a5666251fb7e87ae34ee855f
-      size: 82959943
+      md5: 4e5420ce4b3474248fb5ac0447cd4945
+      size: 84282846
     - path: input/land_nbhd_rate_data.parquet
       hash: md5
-      md5: b4cfaf3d4a35c250990752024a88f3bb
+      md5: cb489a55f638d90898a06976b2a9bda9
       size: 5709
     - path: input/training_data.parquet
       hash: md5
-      md5: 8e34ebaa488c6fbabe56c43dfec41667
-      size: 75827972
+      md5: 020cbfcfa2c04eb7acfdff72d80af4d7
+      size: 76245405
     - path: output/workflow/fit/model_workflow_fit.zip
       hash: md5
-      md5: 8b5ee80cdc31308770dd865edb4c08ae
-      size: 2869594
+      md5: 89d07e1af56dccf16fb2ac6f40cc46a6
+      size: 2873661
     - path: output/workflow/recipe/model_workflow_recipe.rds
       hash: md5
-      md5: 6204871f9d831cf7db9fe62c3598fd20
-      size: 662614341
+      md5: d4ef5751a460e04a19f5d927500698ca
+      size: 665335235
     - path: pipeline/02-assess.R
       hash: md5
       md5: 923794cea0040f78dacf564f76ea8faf
@@ -446,31 +449,31 @@ stages:
     outs:
     - path: output/assessment_card/model_assessment_card.parquet
       hash: md5
-      md5: f338acc34dfa45240d2d4f56b27cebdf
-      size: 45151035
+      md5: ceeac93d034899988c4df568ba417e4b
+      size: 44393022
     - path: output/assessment_pin/model_assessment_pin.parquet
       hash: md5
-      md5: bf013282655b1a44d7f371a02e9e215d
-      size: 38809830
+      md5: 686ddbc05d892c6bbdf07824231e0317
+      size: 38928604
     - path: output/intermediate/timing/model_timing_assess.parquet
       hash: md5
-      md5: 9a53981c0c8bb2dc0f90bb5fcd88deb1
+      md5: 3fba9c99a4abd6a4812d1184cbb78f80
       size: 2494
   evaluate:
     cmd: Rscript pipeline/03-evaluate.R
     deps:
     - path: output/assessment_pin/model_assessment_pin.parquet
       hash: md5
-      md5: bf013282655b1a44d7f371a02e9e215d
-      size: 38809830
+      md5: 686ddbc05d892c6bbdf07824231e0317
+      size: 38928604
     - path: output/test_card/model_test_card.parquet
       hash: md5
-      md5: 1b24c9069bd5f98970de350345bbb095
-      size: 1301224
+      md5: 721ad01070e8be97c0c7d1b946fd1b5e
+      size: 1308629
     - path: pipeline/03-evaluate.R
       hash: md5
-      md5: a1e765acbb7531bdfc17e0cc60508914
-      size: 17400
+      md5: 65297732f5f2acfe2e3c9f4f6997ab38
+      size: 17594
     params:
       params.yaml:
         assessment:
@@ -504,39 +507,40 @@ stages:
     outs:
     - path: output/intermediate/timing/model_timing_evaluate.parquet
       hash: md5
-      md5: 2d4eff9279c3da2bfd23a641606f412f
-      size: 2514
+      md5: 5f615fd0e91a6740451cac51098b8a8a
+      size: 2509
     - path: output/performance/model_performance_assessment.parquet
       hash: md5
-      md5: f8b4181f7dbf6a74a8bb704a05865533
-      size: 299364
+      md5: bffe6e9f726c9eef6e65baf5a9737872
+      size: 393033
     - path: output/performance/model_performance_test.parquet
       hash: md5
-      md5: e6e56cce3c11a87914f75dd12cb47751
-      size: 998741
-    - path: output/performance_quantile/model_performance_quantile_assessment.parquet
+      md5: 1bdcd2e2fe7bb5362748ad07a021315e
+      size: 1270529
+    - path: 
+        output/performance_quantile/model_performance_quantile_assessment.parquet
       hash: md5
-      md5: 773629590f994cf3ebbb7d41eb8d8de3
-      size: 188431
+      md5: d4e52419f5b65c42f09e88d8bd960009
+      size: 187708
     - path: output/performance_quantile/model_performance_quantile_test.parquet
       hash: md5
-      md5: 1abb501e6211f0350c3921c091bf1b0e
-      size: 982831
+      md5: 4fc4b2782c24b88211abb5fc46ffcc67
+      size: 970145
   interpret:
     cmd: Rscript pipeline/04-interpret.R
     deps:
     - path: input/assessment_data.parquet
       hash: md5
-      md5: caaa3525a5666251fb7e87ae34ee855f
-      size: 82959943
+      md5: 4e5420ce4b3474248fb5ac0447cd4945
+      size: 84282846
     - path: output/workflow/fit/model_workflow_fit.zip
       hash: md5
-      md5: 8b5ee80cdc31308770dd865edb4c08ae
-      size: 2869594
+      md5: 89d07e1af56dccf16fb2ac6f40cc46a6
+      size: 2873661
     - path: output/workflow/recipe/model_workflow_recipe.rds
       hash: md5
-      md5: 6204871f9d831cf7db9fe62c3598fd20
-      size: 662614341
+      md5: d4ef5751a460e04a19f5d927500698ca
+      size: 665335235
     - path: pipeline/04-interpret.R
       hash: md5
       md5: 51795fcf45dabc142f57c7b6e524b74b
@@ -628,39 +632,39 @@ stages:
     outs:
     - path: output/feature_importance/model_feature_importance.parquet
       hash: md5
-      md5: 746f0d236462d34ff39854b7bd2504cd
-      size: 7827
+      md5: cf49a0206bb539fd8967d193714894bc
+      size: 7824
     - path: output/intermediate/timing/model_timing_interpret.parquet
       hash: md5
-      md5: d22473ecf2dac9ebd030bf84f4e2a6f5
-      size: 2524
+      md5: d8f66dc26c6552eea87804008d7f036b
+      size: 2519
     - path: output/shap/model_shap.parquet
       hash: md5
-      md5: b378f8ae73167478032391c6cdd3bbad
+      md5: 50552341165b58ede24278a25b8d9952
       size: 501
   finalize:
     cmd: Rscript pipeline/05-finalize.R
     deps:
     - path: output/intermediate/timing/model_timing_assess.parquet
       hash: md5
-      md5: 9a53981c0c8bb2dc0f90bb5fcd88deb1
+      md5: 3fba9c99a4abd6a4812d1184cbb78f80
       size: 2494
     - path: output/intermediate/timing/model_timing_evaluate.parquet
       hash: md5
-      md5: 2d4eff9279c3da2bfd23a641606f412f
-      size: 2514
+      md5: 5f615fd0e91a6740451cac51098b8a8a
+      size: 2509
     - path: output/intermediate/timing/model_timing_interpret.parquet
       hash: md5
-      md5: d22473ecf2dac9ebd030bf84f4e2a6f5
-      size: 2524
+      md5: d8f66dc26c6552eea87804008d7f036b
+      size: 2519
     - path: output/intermediate/timing/model_timing_train.parquet
       hash: md5
-      md5: cf7bb7a8e3fee7b5b3adc3962b3ff972
-      size: 2494
+      md5: db35858510fea9dba6fc258f8c2e26f1
+      size: 2484
     - path: pipeline/05-finalize.R
       hash: md5
-      md5: c25e5ec1a936d176a68f858033b9b136
-      size: 7610
+      md5: 2f41c2d1d5c4324297213e11ad68be79
+      size: 8916
     params:
       params.yaml:
         cv:
@@ -679,6 +683,9 @@ stages:
           building:
             weight_min: 0.1
             weight_max: 1.0
+          subset:
+            enable: false
+            fraction: 0.25
         model:
           engine: lightgbm
           objective: rmse
@@ -900,30 +907,35 @@ stages:
           cv_enable: false
           shap_enable: false
           upload_enable: true
+          feature_report_enable: false
     outs:
     - path: output/intermediate/timing/model_timing_finalize.parquet
       hash: md5
-      md5: 970b13abbcb2e483115531d8fce2d4ce
-      size: 2514
+      md5: 4ee6f92c0e03f273774b065ef6654f1a
+      size: 2509
     - path: output/metadata/model_metadata.parquet
       hash: md5
-      md5: d2e77e0cfc19be1de56e9b3f186a3bb4
-      size: 19199
+      md5: 57c3655136e7158eed040d1fa4ad17cb
+      size: 22424
     - path: output/timing/model_timing.parquet
       hash: md5
-      md5: d28e4d30f546e6564ce1a36a382edbed
-      size: 5128
+      md5: 5146f9a7b457f029c80505e36d26d0ec
+      size: 5143
+    - path: reports/model_features/model_features.html
+      hash: md5
+      md5: 74643eb2c3127e4781b26cf501c8e2f8
+      size: 58
     - path: reports/performance/performance.html
       hash: md5
-      md5: ff622ddf9f8f5870efc4d9c24021c713
-      size: 31589905
+      md5: 863af4d9b855fafb6df723b8510b4148
+      size: 33492755
   export:
     cmd: Rscript pipeline/07-export.R
     deps:
     - path: pipeline/07-export.R
       hash: md5
-      md5: 25b214fcc1b43dea2efe91fbe6b4e674
-      size: 20605
+      md5: 1316c0576c52eeb3c26d26c95b61b53c
+      size: 20235
     params:
       params.yaml:
         assessment.year: '2026'
@@ -958,73 +970,78 @@ stages:
     deps:
     - path: output/assessment_card/model_assessment_card.parquet
       hash: md5
-      md5: f338acc34dfa45240d2d4f56b27cebdf
-      size: 45151035
+      md5: ceeac93d034899988c4df568ba417e4b
+      size: 44393022
     - path: output/assessment_pin/model_assessment_pin.parquet
       hash: md5
-      md5: bf013282655b1a44d7f371a02e9e215d
-      size: 38809830
+      md5: 686ddbc05d892c6bbdf07824231e0317
+      size: 38928604
     - path: output/feature_importance/model_feature_importance.parquet
       hash: md5
-      md5: 746f0d236462d34ff39854b7bd2504cd
-      size: 7827
+      md5: cf49a0206bb539fd8967d193714894bc
+      size: 7824
     - path: output/metadata/model_metadata.parquet
       hash: md5
-      md5: d2e77e0cfc19be1de56e9b3f186a3bb4
-      size: 19199
+      md5: 57c3655136e7158eed040d1fa4ad17cb
+      size: 22424
     - path: output/parameter_final/model_parameter_final.parquet
       hash: md5
       md5: 4e88c21fbd94c9f5a598dcdf670dab7c
       size: 6658
     - path: output/parameter_range/model_parameter_range.parquet
       hash: md5
-      md5: b378f8ae73167478032391c6cdd3bbad
+      md5: 50552341165b58ede24278a25b8d9952
       size: 501
     - path: output/parameter_search/model_parameter_search.parquet
       hash: md5
-      md5: b378f8ae73167478032391c6cdd3bbad
+      md5: 50552341165b58ede24278a25b8d9952
       size: 501
     - path: output/performance/model_performance_assessment.parquet
       hash: md5
-      md5: f8b4181f7dbf6a74a8bb704a05865533
-      size: 299364
+      md5: bffe6e9f726c9eef6e65baf5a9737872
+      size: 393033
     - path: output/performance/model_performance_test.parquet
       hash: md5
-      md5: e6e56cce3c11a87914f75dd12cb47751
-      size: 998741
-    - path: output/performance_quantile/model_performance_quantile_assessment.parquet
+      md5: 1bdcd2e2fe7bb5362748ad07a021315e
+      size: 1270529
+    - path: 
+        output/performance_quantile/model_performance_quantile_assessment.parquet
       hash: md5
-      md5: 773629590f994cf3ebbb7d41eb8d8de3
-      size: 188431
+      md5: d4e52419f5b65c42f09e88d8bd960009
+      size: 187708
     - path: output/performance_quantile/model_performance_quantile_test.parquet
       hash: md5
-      md5: 1abb501e6211f0350c3921c091bf1b0e
-      size: 982831
+      md5: 4fc4b2782c24b88211abb5fc46ffcc67
+      size: 970145
     - path: output/shap/model_shap.parquet
       hash: md5
-      md5: b378f8ae73167478032391c6cdd3bbad
+      md5: 50552341165b58ede24278a25b8d9952
       size: 501
     - path: output/test_card/model_test_card.parquet
       hash: md5
-      md5: 1b24c9069bd5f98970de350345bbb095
-      size: 1301224
+      md5: 721ad01070e8be97c0c7d1b946fd1b5e
+      size: 1308629
     - path: output/timing/model_timing.parquet
       hash: md5
-      md5: d28e4d30f546e6564ce1a36a382edbed
-      size: 5128
+      md5: 5146f9a7b457f029c80505e36d26d0ec
+      size: 5143
     - path: output/workflow/fit/model_workflow_fit.zip
       hash: md5
-      md5: 8b5ee80cdc31308770dd865edb4c08ae
-      size: 2869594
+      md5: 89d07e1af56dccf16fb2ac6f40cc46a6
+      size: 2873661
     - path: output/workflow/recipe/model_workflow_recipe.rds
       hash: md5
-      md5: 6204871f9d831cf7db9fe62c3598fd20
-      size: 662614341
+      md5: d4ef5751a460e04a19f5d927500698ca
+      size: 665335235
     - path: pipeline/06-upload.R
       hash: md5
-      md5: 613632039c6744d3132a8760c1b51099
-      size: 10855
+      md5: 645686fd95cbb5e3c2d0c62cef9a8f11
+      size: 11078
+    - path: reports/model_features/model_features.html
+      hash: md5
+      md5: 74643eb2c3127e4781b26cf501c8e2f8
+      size: 58
     - path: reports/performance/performance.html
       hash: md5
-      md5: ff622ddf9f8f5870efc4d9c24021c713
-      size: 31589905
+      md5: 863af4d9b855fafb6df723b8510b4148
+      size: 33492755


### PR DESCRIPTION
There have been a lot of folks contributing to the model repos recently which has resulted in dvc changes being hard to track. The sole purpose of this PR is to update the lock file.

I ran `dvc repro -f` locally after unfreezing the ingest stage. The diff are the subsequent changes to `dvc.lock`.

`dvc push` was run after `dvc repro -f` completed.