### PR TITLE
Upgrade all third-party actions and pin them to immutable releases

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Run pre-commit checks
         uses: ccao-data/actions/pre-commit@main


### PR DESCRIPTION
This PR upgrades all of our third-party GitHub Actions to ensure they are compatible with the [upcoming Node 20 deprecation](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).

While we're at it, we also switch all of our references to third-party actions to point to immutable releases, so as to protect ourselves from the the ongoing scourge of supply chain attacks against third-party actions. If an action repo is using [immutable releases](https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases), we pin to a specific immutable release; otherwise, we pin to the commit hash for the latest release of that action.

Test workflows to confirm these upgrades don't break anything:

- [x] `pre-commit`: https://github.com/ccao-data/model-condo-avm/actions/runs/26307324224/job/77447273138

Connects https://github.com/ccao-data/aws-infrastructure/issues/59.