### PR TITLE
Add final 2026 hyperparameters

### DIFF
--- a/params.yaml
+++ b/params.yaml
@@ -300,27 +300,27 @@ model:
       # for setting this parameter is to discover a good fixed value using CV,
       # then manually set that value for non-CV runs (which don't use
       # early stopping by default)
-      num_iterations: 1175
-      learning_rate: 0.0375
+      num_iterations: 1844
+      learning_rate: 0.0335
 
       # Maximum number of bins for discretizing continuous features. Lower uses
       # less memory and speeds up training
-      max_bin: 465
+      max_bin: 473
 
       # See docs for details on each of the remaining parameters:
       # https://lightgbm.readthedocs.io/en/latest/Parameters.html
-      num_leaves: 64
-      add_to_linked_depth: 3
-      feature_fraction: 0.559
-      min_gain_to_split: 0.312
-      min_data_in_leaf: 36
-      max_cat_threshold: 175
-      min_data_per_group: 215
-      cat_smooth: 92.06
-      cat_l2: 0.016
-      lambda_l1: 23.739
-      lambda_l2: 0.199
-      imp_trees: 15
+      num_leaves: 51
+      add_to_linked_depth: 7
+      feature_fraction: 0.487
+      min_gain_to_split: 1196.478
+      min_data_in_leaf: 24
+      max_cat_threshold: 165
+      min_data_per_group: 52
+      cat_smooth: 39.66
+      cat_l2: 1.42
+      lambda_l1: 50.389
+      lambda_l2: 0.009
+      imp_trees: 19
 
     # Range of possible hyperparameter values for tuning to explore
     range:


### PR DESCRIPTION
These are the hyperparameters that were discovered using a full CV run and used for our final model run, `2026-02-12-gallant-bowen`. This is the [corresponding res PR](https://github.com/ccao-data/model-res-avm/pull/438). I stuck to preestablished rounding for each hyperparameter.

I'm not sure what should we do about our [2026 tag](https://github.com/ccao-data/model-condo-avm/releases/tag/2026-assessment-year), though.

```sql
select round(num_iterations, 3) as num_iterations,
	round(learning_rate, 4) as learning_rate,
	round(max_bin, 3) as max_bin,
	round(num_leaves, 3) as num_leaves,
	round(add_to_linked_depth, 3) as add_to_linked_depth,
	round(feature_fraction, 3) as feature_fraction,
	round(min_gain_to_split, 3) as min_gain_to_split,
	round(min_data_in_leaf, 3) as min_data_in_leaf,
	round(max_cat_threshold, 3) as max_cat_threshold,
	round(min_data_per_group, 3) as min_data_per_group,
	round(cat_smooth, 3) as cat_smooth,
	round(cat_l2, 3) as cat_l2,
	round(lambda_l1, 3) as lambda_l1,
	round(lambda_l2, 3) as lambda_l2,
	round(imp_trees, 3) as imp_trees
from model.parameter_final
where run_id = '2026-02-12-gallant-bowen'
```