### PR TITLE
Add covariance penalty and logged outcome training support

### DIFF
--- a/R/setup.R
+++ b/R/setup.R
@@ -111,6 +111,27 @@ if (!run_type %in% possible_run_types) {
 }
 rm(possible_run_types)
 
+# Whether to log-transform the sale price target before fitting. Defines model
+# structure (see `model.log_sale_price` in params.yaml), not a pipeline toggle
+log_transform_enable <- as.logical(
+  get(params_obj_name)$model$log_sale_price
+)
+
+# The "mse_cov" objective is only built for logged sale prices. An un-logged
+# configuration exists in the reference Python implementation (the "div"
+# ratio mode) but is not built into our codebase; if there is interest, see
+# the author's repo or working paper:
+# https://github.com/nicacevedo/soft-vertical-equity-constrained-mass-appraissal
+if (
+  identical(get(params_obj_name)$model$objective, "mse_cov") &&
+    !log_transform_enable
+) {
+  stop(
+    "model.objective = 'mse_cov' requires model.log_sale_price = true, ",
+    "since the objective is only built for logged sale prices"
+  )
+}
+
 # Check to see if LightGBM early stopping is enabled based on engine parameters
 early_stopping_enable <-
   get(params_obj_name)$model$parameter$validation_prop > 0 &&

--- a/R/setup.R
+++ b/R/setup.R
@@ -111,8 +111,8 @@ if (!run_type %in% possible_run_types) {
 }
 rm(possible_run_types)
 
-# Whether to log-transform the sale price target before fitting. Defines model
-# structure (see `model.log_sale_price` in params.yaml), not a pipeline toggle
+# Whether to log-transform the sale price target before fitting. (see
+# `model.log_sale_price` in params.yaml)
 log_transform_enable <- as.logical(
   get(params_obj_name)$model$log_sale_price
 )

--- a/dvc.lock
+++ b/dvc.lock
@@ -29,20 +29,20 @@ stages:
     outs:
     - path: input/assessment_data.parquet
       hash: md5
-      md5: 83cc912060c30758de43f268cb223360
-      size: 84461608
+      md5: caaa3525a5666251fb7e87ae34ee855f
+      size: 82959943
     - path: input/char_data.parquet
       hash: md5
-      md5: 5a406ce6ac15f54525b74df654493aa3
-      size: 159461266
+      md5: cde3c37f5af556109a60831eab19a616
+      size: 154961864
     - path: input/land_nbhd_rate_data.parquet
       hash: md5
       md5: b4cfaf3d4a35c250990752024a88f3bb
       size: 5709
     - path: input/training_data.parquet
       hash: md5
-      md5: 6da794ead893bbb1f63ccaaa744d88cf
-      size: 76326224
+      md5: 8e34ebaa488c6fbabe56c43dfec41667
+      size: 75827972
   train:
     cmd: Rscript pipeline/01-train.R
     deps:

--- a/dvc.lock
+++ b/dvc.lock
@@ -29,35 +29,36 @@ stages:
     outs:
     - path: input/assessment_data.parquet
       hash: md5
-      md5: 83cc912060c30758de43f268cb223360
-      size: 84461608
+      md5: caaa3525a5666251fb7e87ae34ee855f
+      size: 82959943
     - path: input/char_data.parquet
       hash: md5
-      md5: 5a406ce6ac15f54525b74df654493aa3
-      size: 159461266
+      md5: cde3c37f5af556109a60831eab19a616
+      size: 154961864
     - path: input/land_nbhd_rate_data.parquet
       hash: md5
       md5: b4cfaf3d4a35c250990752024a88f3bb
       size: 5709
     - path: input/training_data.parquet
       hash: md5
-      md5: 6da794ead893bbb1f63ccaaa744d88cf
-      size: 76326224
+      md5: 8e34ebaa488c6fbabe56c43dfec41667
+      size: 75827972
   train:
     cmd: Rscript pipeline/01-train.R
     deps:
     - path: input/training_data.parquet
       hash: md5
-      md5: 6da794ead893bbb1f63ccaaa744d88cf
-      size: 76326224
+      md5: 8e34ebaa488c6fbabe56c43dfec41667
+      size: 75827972
     - path: pipeline/01-train.R
       hash: md5
-      md5: 760f8431e76732164d76c0cb3aab0b98
-      size: 17596
+      md5: bd1fa5382e360f00ab2ff05a1fe9ff92
+      size: 19332
     params:
       params.yaml:
         cv:
           split_prop: 0.9
+          stratified_prop: 0.0
           num_folds: 7
           fold_overlap: 9
           initial_set: 20
@@ -68,21 +69,21 @@ stages:
         model.engine: lightgbm
         model.hyperparameter:
           default:
-            num_iterations: 1175
-            learning_rate: 0.0375
-            max_bin: 465
-            num_leaves: 64
-            add_to_linked_depth: 3
-            feature_fraction: 0.559
-            min_gain_to_split: 0.312
-            min_data_in_leaf: 36
-            max_cat_threshold: 175
-            min_data_per_group: 215
-            cat_smooth: 92.06
-            cat_l2: 0.016
-            lambda_l1: 23.739
-            lambda_l2: 0.199
-            imp_trees: 15
+            num_iterations: 1844
+            learning_rate: 0.0335
+            max_bin: 473
+            num_leaves: 51
+            add_to_linked_depth: 7
+            feature_fraction: 0.487
+            min_gain_to_split: 1196.478
+            min_data_in_leaf: 24
+            max_cat_threshold: 165
+            min_data_per_group: 52
+            cat_smooth: 39.66
+            cat_l2: 1.42
+            lambda_l1: 50.389
+            lambda_l2: 0.009
+            imp_trees: 19
           range:
             num_iterations:
             - 100
@@ -129,13 +130,15 @@ stages:
             imp_trees:
             - 5
             - 50
-        model.objective: rmse
+        model.log_sale_price: true
+        model.objective: mse_cov
         model.parameter:
           validation_prop: 0.1
           validation_type: recent
           validation_metric: rmse
           link_max_depth: true
           stop_iter: 50
+          mse_cov_rho: 1
         model.predictor:
           all:
           - meta_township_code
@@ -272,63 +275,63 @@ stages:
     outs:
     - path: output/intermediate/timing/model_timing_train.parquet
       hash: md5
-      md5: 1c0c281d49e8d99c9f135db57ea363d3
-      size: 2489
+      md5: 487011e79983ed7c72a26cc431b1c58d
+      size: 2484
     - path: output/parameter_final/model_parameter_final.parquet
       hash: md5
-      md5: 4e88c21fbd94c9f5a598dcdf670dab7c
-      size: 6658
+      md5: 2f951189cf9669e0fc23f42a66d4a2af
+      size: 6932
     - path: output/parameter_range/model_parameter_range.parquet
       hash: md5
-      md5: b378f8ae73167478032391c6cdd3bbad
+      md5: 50552341165b58ede24278a25b8d9952
       size: 501
     - path: output/parameter_search/model_parameter_search.parquet
       hash: md5
-      md5: b378f8ae73167478032391c6cdd3bbad
+      md5: 50552341165b58ede24278a25b8d9952
       size: 501
     - path: output/test_card/model_test_card.parquet
       hash: md5
-      md5: 0f043d7b147f4dbb9c49ca7daeca10f1
-      size: 1309105
+      md5: 4fe3159bc10d16e3df826c714aa8adc8
+      size: 1205336
     - path: output/train_card/model_train_card.parquet
       hash: md5
-      md5: 2057f7955b765ba0f639f267b5668a4a
-      size: 10317119
+      md5: 02b635b1835cd256dbbab65fad4d5f5b
+      size: 9268568
     - path: output/workflow/fit/model_workflow_fit.zip
       hash: md5
-      md5: b17a42229895f3dd066a75de7a78f6f1
-      size: 2872488
+      md5: c781f4fee038dc4f410222ad39305a0d
+      size: 25786
     - path: output/workflow/recipe/model_workflow_recipe.rds
       hash: md5
-      md5: ffc6619912b66ebf742519c9adfbc5b2
-      size: 665857542
+      md5: 6fbecba86c976d882616464548a6a81f
+      size: 831810306
   assess:
     cmd: Rscript pipeline/02-assess.R
     deps:
     - path: input/assessment_data.parquet
       hash: md5
-      md5: 83cc912060c30758de43f268cb223360
-      size: 84461608
+      md5: caaa3525a5666251fb7e87ae34ee855f
+      size: 82959943
     - path: input/land_nbhd_rate_data.parquet
       hash: md5
       md5: b4cfaf3d4a35c250990752024a88f3bb
       size: 5709
     - path: input/training_data.parquet
       hash: md5
-      md5: 6da794ead893bbb1f63ccaaa744d88cf
-      size: 76326224
+      md5: 8e34ebaa488c6fbabe56c43dfec41667
+      size: 75827972
     - path: output/workflow/fit/model_workflow_fit.zip
       hash: md5
-      md5: b17a42229895f3dd066a75de7a78f6f1
-      size: 2872488
+      md5: c781f4fee038dc4f410222ad39305a0d
+      size: 25786
     - path: output/workflow/recipe/model_workflow_recipe.rds
       hash: md5
-      md5: ffc6619912b66ebf742519c9adfbc5b2
-      size: 665857542
+      md5: 6fbecba86c976d882616464548a6a81f
+      size: 831810306
     - path: pipeline/02-assess.R
       hash: md5
-      md5: 923794cea0040f78dacf564f76ea8faf
-      size: 16415
+      md5: ff389ec63a2041822f895352b50c6ac9
+      size: 16612
     params:
       params.yaml:
         assessment:
@@ -338,6 +341,7 @@ stages:
           group: condo
           data_year: '2025'
           working_year: '2026'
+        model.log_sale_price: true
         model.predictor.all:
         - meta_township_code
         - meta_nbhd_code
@@ -453,31 +457,31 @@ stages:
     outs:
     - path: output/assessment_card/model_assessment_card.parquet
       hash: md5
-      md5: 45166c034de301e646a5cbd8bfcd8705
-      size: 44025035
+      md5: 57846328b69d364572596435391e9595
+      size: 43942618
     - path: output/assessment_pin/model_assessment_pin.parquet
       hash: md5
-      md5: 286d4d125fc4c994fa9ffdcbae749e1d
-      size: 38774716
+      md5: 0b5c037be79fbd2acf756922c3d51f5d
+      size: 38864375
     - path: output/intermediate/timing/model_timing_assess.parquet
       hash: md5
-      md5: 541bede2b9187a525cb1611a640518b7
+      md5: 720f3609eef834a795ea12ef18d84a77
       size: 2494
   evaluate:
     cmd: Rscript pipeline/03-evaluate.R
     deps:
     - path: output/assessment_pin/model_assessment_pin.parquet
       hash: md5
-      md5: 286d4d125fc4c994fa9ffdcbae749e1d
-      size: 38774716
+      md5: 0b5c037be79fbd2acf756922c3d51f5d
+      size: 38864375
     - path: output/test_card/model_test_card.parquet
       hash: md5
-      md5: 0f043d7b147f4dbb9c49ca7daeca10f1
-      size: 1309105
+      md5: 4fe3159bc10d16e3df826c714aa8adc8
+      size: 1205336
     - path: output/train_card/model_train_card.parquet
       hash: md5
-      md5: 2057f7955b765ba0f639f267b5668a4a
-      size: 10317119
+      md5: 02b635b1835cd256dbbab65fad4d5f5b
+      size: 9268568
     - path: pipeline/03-evaluate.R
       hash: md5
       md5: c57bfa1db658b0fd5706799ba93ebfa6
@@ -515,63 +519,66 @@ stages:
     outs:
     - path: output/intermediate/timing/model_timing_evaluate.parquet
       hash: md5
-      md5: 66b7dd7a9a86fcbd33c70a41b9c27df9
+      md5: 4086ffc35b5b8b05066986e2c4b3bd56
       size: 2514
     - path: output/performance/model_performance_assessment.parquet
       hash: md5
-      md5: 45f446964447d224f315307f070641d8
-      size: 393494
+      md5: db1629a2b2eac8644c31d4e4e40ac53e
+      size: 385676
     - path: output/performance/model_performance_test.parquet
       hash: md5
-      md5: 7e727d2018a2a9d8e510111ed1755c1c
-      size: 1269985
+      md5: 57c133a0364abfc49f6e2265ca96707b
+      size: 1254287
     - path: output/performance/model_performance_test_linear.parquet
       hash: md5
-      md5: 96378f5afae425ae11cdbee2d01ee49b
-      size: 1270700
+      md5: 24b7a47d6b2417b455f1953a96ced38a
+      size: 1262507
     - path: output/performance/model_performance_train.parquet
       hash: md5
-      md5: 4d30252943bee9a610ed8f17eba82854
-      size: 1746944
+      md5: 2928931c86493ce14a67b17023142e31
+      size: 1733897
     - path: output/performance/model_performance_train_linear.parquet
       hash: md5
-      md5: b3dffe58b00e58e6f6507bcfed55368d
-      size: 1747626
-    - path: output/performance_quantile/model_performance_quantile_assessment.parquet
+      md5: 3f6b607e4bb3e5d56d1fafa804362ea4
+      size: 1749455
+    - path: 
+        output/performance_quantile/model_performance_quantile_assessment.parquet
       hash: md5
-      md5: db495c4941c4664b51f8e75549df94df
-      size: 188516
+      md5: 14ad132378aa84ad219258e556693984
+      size: 188591
     - path: output/performance_quantile/model_performance_quantile_test.parquet
       hash: md5
-      md5: 3e7b260e978f318293d823215f7130e5
-      size: 970954
-    - path: output/performance_quantile/model_performance_quantile_test_linear.parquet
+      md5: 80a8d7bbf4382e35a1b0564fc5054808
+      size: 958019
+    - path: 
+        output/performance_quantile/model_performance_quantile_test_linear.parquet
       hash: md5
-      md5: e6ab8a4fef52f5e08e964a24269b6306
-      size: 973290
+      md5: 712fb208d1a47a04cba9e6ea117d23cd
+      size: 985543
     - path: output/performance_quantile/model_performance_quantile_train.parquet
       hash: md5
-      md5: 256b7c81a85b938a6ca622d4033459ae
-      size: 1591625
-    - path: output/performance_quantile/model_performance_quantile_train_linear.parquet
+      md5: 2e3dd8b3b349a680d7428d1848415544
+      size: 1582914
+    - path: 
+        output/performance_quantile/model_performance_quantile_train_linear.parquet
       hash: md5
-      md5: b1fa82e9a2ad2612989632a7b508c3a6
-      size: 1602049
+      md5: 2e57b81f4966c8f67e425d0aad9885ac
+      size: 1604002
   interpret:
     cmd: Rscript pipeline/04-interpret.R
     deps:
     - path: input/assessment_data.parquet
       hash: md5
-      md5: 83cc912060c30758de43f268cb223360
-      size: 84461608
+      md5: caaa3525a5666251fb7e87ae34ee855f
+      size: 82959943
     - path: output/workflow/fit/model_workflow_fit.zip
       hash: md5
-      md5: b17a42229895f3dd066a75de7a78f6f1
-      size: 2872488
+      md5: c781f4fee038dc4f410222ad39305a0d
+      size: 25786
     - path: output/workflow/recipe/model_workflow_recipe.rds
       hash: md5
-      md5: ffc6619912b66ebf742519c9adfbc5b2
-      size: 665857542
+      md5: 6fbecba86c976d882616464548a6a81f
+      size: 831810306
     - path: pipeline/04-interpret.R
       hash: md5
       md5: 51795fcf45dabc142f57c7b6e524b74b
@@ -663,43 +670,44 @@ stages:
     outs:
     - path: output/feature_importance/model_feature_importance.parquet
       hash: md5
-      md5: 86eef8ba9b1a0d7272dc179ed35f5c69
-      size: 7832
+      md5: 3ee169152daf63b70d6be7840d884b41
+      size: 4263
     - path: output/intermediate/timing/model_timing_interpret.parquet
       hash: md5
-      md5: ecd6901b61121edc59e5c1fb4973ba27
+      md5: ea0db766125c170daa851ba50f01287d
       size: 2519
     - path: output/shap/model_shap.parquet
       hash: md5
-      md5: b378f8ae73167478032391c6cdd3bbad
+      md5: 50552341165b58ede24278a25b8d9952
       size: 501
   finalize:
     cmd: Rscript pipeline/05-finalize.R
     deps:
     - path: output/intermediate/timing/model_timing_assess.parquet
       hash: md5
-      md5: 541bede2b9187a525cb1611a640518b7
+      md5: 720f3609eef834a795ea12ef18d84a77
       size: 2494
     - path: output/intermediate/timing/model_timing_evaluate.parquet
       hash: md5
-      md5: 66b7dd7a9a86fcbd33c70a41b9c27df9
+      md5: 4086ffc35b5b8b05066986e2c4b3bd56
       size: 2514
     - path: output/intermediate/timing/model_timing_interpret.parquet
       hash: md5
-      md5: ecd6901b61121edc59e5c1fb4973ba27
+      md5: ea0db766125c170daa851ba50f01287d
       size: 2519
     - path: output/intermediate/timing/model_timing_train.parquet
       hash: md5
-      md5: 1c0c281d49e8d99c9f135db57ea363d3
-      size: 2489
+      md5: 487011e79983ed7c72a26cc431b1c58d
+      size: 2484
     - path: pipeline/05-finalize.R
       hash: md5
-      md5: 2f41c2d1d5c4324297213e11ad68be79
-      size: 8916
+      md5: 4e4328dba6f8c94be897a493947d024f
+      size: 9099
     params:
       params.yaml:
         cv:
           split_prop: 0.9
+          stratified_prop: 0.0
           num_folds: 7
           fold_overlap: 9
           initial_set: 20
@@ -719,7 +727,8 @@ stages:
             fraction: 0.25
         model:
           engine: lightgbm
-          objective: rmse
+          objective: mse_cov
+          log_sale_price: true
           seed: 2026
           deterministic: true
           force_row_wise: true
@@ -839,23 +848,24 @@ stages:
             validation_metric: rmse
             link_max_depth: true
             stop_iter: 50
+            mse_cov_rho: 1
           hyperparameter:
             default:
-              num_iterations: 1175
-              learning_rate: 0.0375
-              max_bin: 465
-              num_leaves: 64
-              add_to_linked_depth: 3
-              feature_fraction: 0.559
-              min_gain_to_split: 0.312
-              min_data_in_leaf: 36
-              max_cat_threshold: 175
-              min_data_per_group: 215
-              cat_smooth: 92.06
-              cat_l2: 0.016
-              lambda_l1: 23.739
-              lambda_l2: 0.199
-              imp_trees: 15
+              num_iterations: 1844
+              learning_rate: 0.0335
+              max_bin: 473
+              num_leaves: 51
+              add_to_linked_depth: 7
+              feature_fraction: 0.487
+              min_gain_to_split: 1196.478
+              min_data_in_leaf: 24
+              max_cat_threshold: 165
+              min_data_per_group: 52
+              cat_smooth: 39.66
+              cat_l2: 1.42
+              lambda_l1: 50.389
+              lambda_l2: 0.009
+              imp_trees: 19
             range:
               num_iterations:
               - 100
@@ -933,7 +943,7 @@ stages:
           - loc_school_elementary_district_geoid
           - loc_school_secondary_district_geoid
           - loc_school_unified_district_geoid
-        run_note: Potential baseline 2026 condo model run with SHAP values
+        run_note: Test covariance penalty term in condo model
         toggle:
           cv_enable: false
           shap_enable: false
@@ -942,24 +952,24 @@ stages:
     outs:
     - path: output/intermediate/timing/model_timing_finalize.parquet
       hash: md5
-      md5: dc7324bddc639953ff5394da8fd7522b
-      size: 2504
+      md5: 4345dbff4a266eb5ece6443002a148c8
+      size: 2514
     - path: output/metadata/model_metadata.parquet
       hash: md5
-      md5: 61fd0d05635bad7d8e780b075ef55b29
-      size: 20096
+      md5: 5a11e42b700a22de4ca016d41c1b93c3
+      size: 20198
     - path: output/timing/model_timing.parquet
       hash: md5
-      md5: e894c39c09f2043bcab0f055c96bd971
-      size: 5123
+      md5: 533a8f4eef79418d9fd9f8047663b9e7
+      size: 5143
     - path: reports/model_features/model_features.html
       hash: md5
       md5: 74643eb2c3127e4781b26cf501c8e2f8
       size: 58
     - path: reports/performance/performance.html
       hash: md5
-      md5: 004b653e50e9513fc04ad1fc1d5ca544
-      size: 80
+      md5: d6758c14335eb218e6dd1d80e2fe84b4
+      size: 31678653
   export:
     cmd: Rscript pipeline/07-export.R
     deps:
@@ -1001,105 +1011,108 @@ stages:
     deps:
     - path: output/assessment_card/model_assessment_card.parquet
       hash: md5
-      md5: 45166c034de301e646a5cbd8bfcd8705
-      size: 44025035
+      md5: 57846328b69d364572596435391e9595
+      size: 43942618
     - path: output/assessment_pin/model_assessment_pin.parquet
       hash: md5
-      md5: 286d4d125fc4c994fa9ffdcbae749e1d
-      size: 38774716
+      md5: 0b5c037be79fbd2acf756922c3d51f5d
+      size: 38864375
     - path: output/feature_importance/model_feature_importance.parquet
       hash: md5
-      md5: 86eef8ba9b1a0d7272dc179ed35f5c69
-      size: 7832
+      md5: 3ee169152daf63b70d6be7840d884b41
+      size: 4263
     - path: output/metadata/model_metadata.parquet
       hash: md5
-      md5: 61fd0d05635bad7d8e780b075ef55b29
-      size: 20096
+      md5: 5a11e42b700a22de4ca016d41c1b93c3
+      size: 20198
     - path: output/parameter_final/model_parameter_final.parquet
       hash: md5
-      md5: 4e88c21fbd94c9f5a598dcdf670dab7c
-      size: 6658
+      md5: 2f951189cf9669e0fc23f42a66d4a2af
+      size: 6932
     - path: output/parameter_range/model_parameter_range.parquet
       hash: md5
-      md5: b378f8ae73167478032391c6cdd3bbad
+      md5: 50552341165b58ede24278a25b8d9952
       size: 501
     - path: output/parameter_search/model_parameter_search.parquet
       hash: md5
-      md5: b378f8ae73167478032391c6cdd3bbad
+      md5: 50552341165b58ede24278a25b8d9952
       size: 501
     - path: output/performance/model_performance_assessment.parquet
       hash: md5
-      md5: 45f446964447d224f315307f070641d8
-      size: 393494
+      md5: db1629a2b2eac8644c31d4e4e40ac53e
+      size: 385676
     - path: output/performance/model_performance_test.parquet
       hash: md5
-      md5: 7e727d2018a2a9d8e510111ed1755c1c
-      size: 1269985
+      md5: 57c133a0364abfc49f6e2265ca96707b
+      size: 1254287
     - path: output/performance/model_performance_test_linear.parquet
       hash: md5
-      md5: 96378f5afae425ae11cdbee2d01ee49b
-      size: 1270700
+      md5: 24b7a47d6b2417b455f1953a96ced38a
+      size: 1262507
     - path: output/performance/model_performance_train.parquet
       hash: md5
-      md5: 4d30252943bee9a610ed8f17eba82854
-      size: 1746944
+      md5: 2928931c86493ce14a67b17023142e31
+      size: 1733897
     - path: output/performance/model_performance_train_linear.parquet
       hash: md5
-      md5: b3dffe58b00e58e6f6507bcfed55368d
-      size: 1747626
-    - path: output/performance_quantile/model_performance_quantile_assessment.parquet
+      md5: 3f6b607e4bb3e5d56d1fafa804362ea4
+      size: 1749455
+    - path: 
+        output/performance_quantile/model_performance_quantile_assessment.parquet
       hash: md5
-      md5: db495c4941c4664b51f8e75549df94df
-      size: 188516
+      md5: 14ad132378aa84ad219258e556693984
+      size: 188591
     - path: output/performance_quantile/model_performance_quantile_test.parquet
       hash: md5
-      md5: 3e7b260e978f318293d823215f7130e5
-      size: 970954
-    - path: output/performance_quantile/model_performance_quantile_test_linear.parquet
+      md5: 80a8d7bbf4382e35a1b0564fc5054808
+      size: 958019
+    - path: 
+        output/performance_quantile/model_performance_quantile_test_linear.parquet
       hash: md5
-      md5: e6ab8a4fef52f5e08e964a24269b6306
-      size: 973290
+      md5: 712fb208d1a47a04cba9e6ea117d23cd
+      size: 985543
     - path: output/performance_quantile/model_performance_quantile_train.parquet
       hash: md5
-      md5: 256b7c81a85b938a6ca622d4033459ae
-      size: 1591625
-    - path: output/performance_quantile/model_performance_quantile_train_linear.parquet
+      md5: 2e3dd8b3b349a680d7428d1848415544
+      size: 1582914
+    - path: 
+        output/performance_quantile/model_performance_quantile_train_linear.parquet
       hash: md5
-      md5: b1fa82e9a2ad2612989632a7b508c3a6
-      size: 1602049
+      md5: 2e57b81f4966c8f67e425d0aad9885ac
+      size: 1604002
     - path: output/shap/model_shap.parquet
       hash: md5
-      md5: b378f8ae73167478032391c6cdd3bbad
+      md5: 50552341165b58ede24278a25b8d9952
       size: 501
     - path: output/test_card/model_test_card.parquet
       hash: md5
-      md5: 0f043d7b147f4dbb9c49ca7daeca10f1
-      size: 1309105
+      md5: 4fe3159bc10d16e3df826c714aa8adc8
+      size: 1205336
     - path: output/timing/model_timing.parquet
       hash: md5
-      md5: e894c39c09f2043bcab0f055c96bd971
-      size: 5123
+      md5: 533a8f4eef79418d9fd9f8047663b9e7
+      size: 5143
     - path: output/train_card/model_train_card.parquet
       hash: md5
-      md5: 2057f7955b765ba0f639f267b5668a4a
-      size: 10317119
+      md5: 02b635b1835cd256dbbab65fad4d5f5b
+      size: 9268568
     - path: output/workflow/fit/model_workflow_fit.zip
       hash: md5
-      md5: b17a42229895f3dd066a75de7a78f6f1
-      size: 2872488
+      md5: c781f4fee038dc4f410222ad39305a0d
+      size: 25786
     - path: output/workflow/recipe/model_workflow_recipe.rds
       hash: md5
-      md5: ffc6619912b66ebf742519c9adfbc5b2
-      size: 665857542
+      md5: 6fbecba86c976d882616464548a6a81f
+      size: 831810306
     - path: pipeline/06-upload.R
       hash: md5
-      md5: cb4ee4819b9651877430c3110d0d7658
-      size: 12148
+      md5: b5ba7b446f28ab78440eebf8d7967755
+      size: 12930
     - path: reports/model_features/model_features.html
       hash: md5
       md5: 74643eb2c3127e4781b26cf501c8e2f8
       size: 58
     - path: reports/performance/performance.html
       hash: md5
-      md5: 004b653e50e9513fc04ad1fc1d5ca544
-      size: 80
+      md5: d6758c14335eb218e6dd1d80e2fe84b4
+      size: 31678653

--- a/dvc.lock
+++ b/dvc.lock
@@ -29,20 +29,20 @@ stages:
     outs:
     - path: input/assessment_data.parquet
       hash: md5
-      md5: caaa3525a5666251fb7e87ae34ee855f
-      size: 82959943
+      md5: 83cc912060c30758de43f268cb223360
+      size: 84461608
     - path: input/char_data.parquet
       hash: md5
-      md5: cde3c37f5af556109a60831eab19a616
-      size: 154961864
+      md5: 5a406ce6ac15f54525b74df654493aa3
+      size: 159461266
     - path: input/land_nbhd_rate_data.parquet
       hash: md5
       md5: b4cfaf3d4a35c250990752024a88f3bb
       size: 5709
     - path: input/training_data.parquet
       hash: md5
-      md5: 8e34ebaa488c6fbabe56c43dfec41667
-      size: 75827972
+      md5: 6da794ead893bbb1f63ccaaa744d88cf
+      size: 76326224
   train:
     cmd: Rscript pipeline/01-train.R
     deps:

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -26,6 +26,7 @@ stages:
     - cv
     - model.engine
     - model.hyperparameter
+    - model.log_sale_price
     - model.objective
     - model.parameter
     - model.predictor
@@ -66,6 +67,7 @@ stages:
     - output/workflow/recipe/model_workflow_recipe.rds
     params:
     - assessment
+    - model.log_sale_price
     - model.predictor.all
     - pv
     - ratio_study

--- a/params.yaml
+++ b/params.yaml
@@ -300,7 +300,7 @@ model:
     # Only used when `model.objective` is set to "mse_cov"; ignored otherwise.
     # 0 recovers plain MSE; larger values penalize Cov(residual, y) more
     # strongly
-    mse_cov_rho: 2
+    mse_cov_rho: 1
 
   hyperparameter:
     # Default set of hyperparameters to use if CV is not enabled

--- a/params.yaml
+++ b/params.yaml
@@ -314,27 +314,27 @@ model:
       # for setting this parameter is to discover a good fixed value using CV,
       # then manually set that value for non-CV runs (which don't use
       # early stopping by default)
-      num_iterations: 2500
-      learning_rate: 0.015048376591892457
+      num_iterations: 1844
+      learning_rate: 0.0335
 
       # Maximum number of bins for discretizing continuous features. Lower uses
       # less memory and speeds up training
-      max_bin: 495
+      max_bin: 473
 
       # See docs for details on each of the remaining parameters:
       # https://lightgbm.readthedocs.io/en/latest/Parameters.html
-      num_leaves: 984
-      add_to_linked_depth: 3
-      feature_fraction: 0.5278147820231877
-      min_gain_to_split: 0.001567624456382694
-      min_data_in_leaf: 211
-      max_cat_threshold: 205
-      min_data_per_group: 118
-      cat_smooth: 101.89281881344877
-      cat_l2: 0.005244204419153175
-      lambda_l1: 0.4797546477585553
-      lambda_l2: 0.11233593979202745
-      imp_trees: 16
+      num_leaves: 51
+      add_to_linked_depth: 7
+      feature_fraction: 0.487
+      min_gain_to_split: 1196.478
+      min_data_in_leaf: 24
+      max_cat_threshold: 165
+      min_data_per_group: 52
+      cat_smooth: 39.66
+      cat_l2: 1.42
+      lambda_l1: 50.389
+      lambda_l2: 0.009
+      imp_trees: 19
 
     # Range of possible hyperparameter values for tuning to explore
     range:

--- a/params.yaml
+++ b/params.yaml
@@ -11,11 +11,11 @@
 
 # Model tag used to identify the purpose of the run. Must be one of:
 # "junk", "rejected", "test", "baseline", "candidate", or "final"
-run_type: "baseline"
+run_type: "test"
 
 # Note included with each run. Use this to summarize what changed about the run
 # or add context
-run_note: Potential baseline 2026 condo model run with SHAP values
+run_note: Test covariance penalty term in condo model
 
 toggle:
   # Should the train stage run full cross-validation? Otherwise, the model
@@ -134,9 +134,17 @@ cv:
 model:
   engine: "lightgbm"
 
-  # Objective/loss function minimized by LightGBM. See website for possible
-  # options: https://lightgbm.readthedocs.io/en/latest/Parameters.html#objective
-  objective: "rmse"
+  # Objective/loss function minimized by LightGBM. Standard LightGBM names
+  # like "rmse" / "regression" / "regression_l1" pass straight through. The
+  # special value "mse_cov" selects lightsnip's custom MSE + rho * Cov(r, y)^2
+  # objective (a soft vertical-equity penalty); when used, set
+  # `model.parameter.mse_cov_rho` below to control the penalty weight.
+  # See: https://lightgbm.readthedocs.io/en/latest/Parameters.html#objective
+  objective: "mse_cov"
+
+  # Log-transform `meta_sale_price` before fitting LightGBM; predictions are
+  # exp()-scaled back to dollars. The linear baseline always uses log(price).
+  log_sale_price: true
 
   # Parameters related to model determinism. Current settings should force
   # the same output every time if the same hyperparameters are used
@@ -287,6 +295,12 @@ model:
     # During CV, the number of iterations to go without improvement before
     # stopping training. Early stopping is deactivated when NULL
     stop_iter: 50
+
+    # Penalty weight (rho) for the lightsnip "mse_cov" custom objective.
+    # Only used when `model.objective` is set to "mse_cov"; ignored otherwise.
+    # 0 recovers plain MSE; larger values penalize Cov(residual, y) more
+    # strongly
+    mse_cov_rho: 1
 
   hyperparameter:
     # Default set of hyperparameters to use if CV is not enabled

--- a/params.yaml
+++ b/params.yaml
@@ -300,7 +300,7 @@ model:
     # Only used when `model.objective` is set to "mse_cov"; ignored otherwise.
     # 0 recovers plain MSE; larger values penalize Cov(residual, y) more
     # strongly
-    mse_cov_rho: 1
+    mse_cov_rho: 2
 
   hyperparameter:
     # Default set of hyperparameters to use if CV is not enabled

--- a/params.yaml
+++ b/params.yaml
@@ -314,27 +314,27 @@ model:
       # for setting this parameter is to discover a good fixed value using CV,
       # then manually set that value for non-CV runs (which don't use
       # early stopping by default)
-      num_iterations: 1844
-      learning_rate: 0.0335
+      num_iterations: 2500
+      learning_rate: 0.015048376591892457
 
       # Maximum number of bins for discretizing continuous features. Lower uses
       # less memory and speeds up training
-      max_bin: 473
+      max_bin: 495
 
       # See docs for details on each of the remaining parameters:
       # https://lightgbm.readthedocs.io/en/latest/Parameters.html
-      num_leaves: 51
-      add_to_linked_depth: 7
-      feature_fraction: 0.487
-      min_gain_to_split: 1196.478
-      min_data_in_leaf: 24
-      max_cat_threshold: 165
-      min_data_per_group: 52
-      cat_smooth: 39.66
-      cat_l2: 1.42
-      lambda_l1: 50.389
-      lambda_l2: 0.009
-      imp_trees: 19
+      num_leaves: 984
+      add_to_linked_depth: 3
+      feature_fraction: 0.5278147820231877
+      min_gain_to_split: 0.001567624456382694
+      min_data_in_leaf: 211
+      max_cat_threshold: 205
+      min_data_per_group: 118
+      cat_smooth: 101.89281881344877
+      cat_l2: 0.005244204419153175
+      lambda_l1: 0.4797546477585553
+      lambda_l2: 0.11233593979202745
+      imp_trees: 16
 
     # Range of possible hyperparameter values for tuning to explore
     range:

--- a/params.yaml
+++ b/params.yaml
@@ -11,11 +11,11 @@
 
 # Model tag used to identify the purpose of the run. Must be one of:
 # "junk", "rejected", "test", "baseline", "candidate", or "final"
-run_type: "test"
+run_type: "baseline"
 
 # Note included with each run. Use this to summarize what changed about the run
 # or add context
-run_note: Test covariance penalty term in condo model
+run_note: Potential baseline 2026 condo model run with SHAP values
 
 toggle:
   # Should the train stage run full cross-validation? Otherwise, the model

--- a/pipeline/01-train.R
+++ b/pipeline/01-train.R
@@ -30,6 +30,15 @@ training_data_full <- read_parquet(paths$input$training$local) %>%
   filter(!sv_is_outlier) %>%
   arrange(meta_sale_date)
 
+# Log-transform sale prices for LightGBM; stash originals for evaluation
+if (log_transform_enable) {
+  training_data_full <- training_data_full %>%
+    mutate(
+      meta_sale_price_original = meta_sale_price,
+      meta_sale_price = log(meta_sale_price)
+    )
+}
+
 # Create train/test split by time, with most recent observations in the test set
 # We want our best model(s) to be predictive of the future, since properties are
 # assessed on the basis of past sales
@@ -80,10 +89,14 @@ train_recipe <- model_main_recipe(
 message("Creating and fitting linear baseline model")
 
 # Create a linear model recipe with additional imputation, transformations,
-# and feature interactions
+# and feature interactions. Linear baseline always fits on log(price);
+# apply here if global transform is off
 lin_recipe <- model_lin_recipe(
-  data = training_data_full %>%
-    mutate(meta_sale_price = log(meta_sale_price)),
+  data = if (log_transform_enable) {
+    training_data_full
+  } else {
+    training_data_full %>% mutate(meta_sale_price = log(meta_sale_price))
+  },
   pred_vars = params$model$predictor$all,
   cat_vars = params$model$predictor$categorical,
   imp = params$model$predictor$imp,
@@ -103,12 +116,16 @@ lin_wflow <- workflow() %>%
     blueprint = hardhat::default_recipe_blueprint(allow_novel_levels = TRUE)
   )
 
-# Fit the linear model on the training data
+# Fit linear baseline; apply log transform to train if global transform is off
 lin_wflow_final_fit <- lin_wflow %>%
   finalize_workflow(
     list(imp_trees = params$model$hyperparameter$default$imp_trees)
   ) %>%
-  fit(data = train %>% mutate(meta_sale_price = log(meta_sale_price)))
+  fit(data = if (log_transform_enable) {
+    train
+  } else {
+    train %>% mutate(meta_sale_price = log(meta_sale_price))
+  })
 
 
 
@@ -150,8 +167,12 @@ lgbm_model <- parsnip::boost_tree(
     num_threads = num_threads,
     verbose = params$model$verbose,
 
-    # Set the objective function. This is what lightgbm will try to minimize
+    # Set the objective function. This is what lightgbm will try to minimize.
+    # When set to "mse_cov", lightsnip swaps in a custom MSE + rho*Cov(r,y)^2
+    # objective and uses `mse_cov_rho` (below) as the penalty weight. For
+    # standard LightGBM objectives the rho value is silently ignored.
     objective = params$model$objective,
+    mse_cov_rho = params$model$parameter$mse_cov_rho,
 
     # Names of integer-encoded categorical columns. This is CRITICAL or else
     # lightgbm will treat these columns as numeric
@@ -414,14 +435,28 @@ walk2(
   list(test, train),
   list(paths$output$test_card$local, paths$output$train_card$local),
   \(data, path) {
-    data %>%
+    preds <- data %>%
       mutate(
         pred_card_initial_fmv = predict(lgbm_wflow_final_fit, data)$.pred,
         pred_card_initial_fmv_lin = exp(predict(
           lin_wflow_final_fit,
-          data %>% mutate(meta_sale_price = log(meta_sale_price))
+          if (log_transform_enable) {
+            data
+          } else {
+            data %>% mutate(meta_sale_price = log(meta_sale_price))
+          }
         )$.pred)
-      ) %>%
+      )
+
+    if (log_transform_enable) {
+      preds <- preds %>%
+        mutate(
+          pred_card_initial_fmv = exp(pred_card_initial_fmv),
+          meta_sale_price = meta_sale_price_original
+        )
+    }
+
+    preds %>%
       select(
         meta_year, meta_pin, meta_class, meta_card_num, meta_triad_code,
         all_of(params$ratio_study$geographies), char_building_sf, char_unit_sf,

--- a/pipeline/02-assess.R
+++ b/pipeline/02-assess.R
@@ -66,6 +66,12 @@ assessment_data_pred <- assessment_data_pred %>%
     )
   )
 
+# Exponentiate predictions back to raw dollar scale
+if (log_transform_enable) {
+  assessment_data_pred <- assessment_data_pred %>%
+    mutate(pred_card_initial_fmv = exp(pred_card_initial_fmv))
+}
+
 
 
 

--- a/pipeline/05-finalize.R
+++ b/pipeline/05-finalize.R
@@ -85,6 +85,7 @@ metadata <- tibble::tibble(
   ratio_study_num_quantile = list(params$ratio_study$num_quantile),
   shap_enable = shap_enable,
   cv_enable = cv_enable,
+  log_transform_enable = log_transform_enable,
   cv_num_folds = params$cv$num_folds,
   cv_fold_overlap = params$cv$fold_overlap,
   cv_initial_set = params$cv$initial_set,

--- a/pipeline/06-upload.R
+++ b/pipeline/06-upload.R
@@ -93,15 +93,29 @@ if (upload_enable) {
       relocate(run_id) %>%
       write_parquet(paths$output$parameter_range$s3)
 
-    # Clean and unnest the raw parameters data, then write the results to S3
+    # Clean and unnest the raw parameters data, then write the results to S3.
+    # Notes (warnings/errors captured by tune during CV) are collapsed to one
+    # row per resample + iteration before joining. A single resample can emit
+    # one note per fit (e.g. the custom objective prediction warning), and
+    # those notes aren't attributable to individual configs, so a natural join
+    # on the unnested rows would fan out the metrics side and break the
+    # row alignment assumed by bind_cols() below
     bind_cols(
       read_parquet(paths$output$parameter_raw$local) %>%
         tidyr::unnest(cols = .metrics) %>%
         mutate(run_id = !!run_id) %>%
         left_join(
-          rename(., notes = .notes) %>%
-            tidyr::unnest(cols = notes) %>%
-            rename(notes = note)
+          read_parquet(paths$output$parameter_raw$local) %>%
+            select(id, .iter, .notes) %>%
+            tidyr::unnest(cols = .notes) %>%
+            group_by(id, .iter) %>%
+            summarize(
+              location = paste(unique(location), collapse = "; "),
+              type = paste(unique(type), collapse = "; "),
+              notes = paste(unique(note), collapse = "; "),
+              .groups = "drop"
+            ),
+          by = c("id", ".iter")
         ) %>%
         select(-.notes) %>%
         rename_with(~ gsub("^\\.", "", .x)) %>%

--- a/pipeline/06-upload.R
+++ b/pipeline/06-upload.R
@@ -98,10 +98,12 @@ if (upload_enable) {
       read_parquet(paths$output$parameter_raw$local) %>%
         tidyr::unnest(cols = .metrics) %>%
         mutate(run_id = !!run_id) %>%
-        # Notes aren't keyed to configs (tune records one per fit, e.g. custom
-        # objective warnings), so collapse them to one row per resample +
-        # iteration before joining. Joining them unnested would fan out the
-        # metrics rows and break the bind_cols() alignment below
+        # Each model fit can leave a warning in .notes (e.g. the custom
+        # objective warning), but notes don't record which config produced
+        # them. At .iter = 0 each fold holds all 20 initial configs, so
+        # joining the notes unnested would attach all 20 warnings to every
+        # metrics row for that fold. Collapse notes to one row per fold and
+        # iteration first so the join can't multiply rows
         left_join(
           read_parquet(paths$output$parameter_raw$local) %>%
             select(id, .iter, .notes) %>%

--- a/pipeline/06-upload.R
+++ b/pipeline/06-upload.R
@@ -93,17 +93,15 @@ if (upload_enable) {
       relocate(run_id) %>%
       write_parquet(paths$output$parameter_range$s3)
 
-    # Clean and unnest the raw parameters data, then write the results to S3.
-    # Notes (warnings/errors captured by tune during CV) are collapsed to one
-    # row per resample + iteration before joining. A single resample can emit
-    # one note per fit (e.g. the custom objective prediction warning), and
-    # those notes aren't attributable to individual configs, so a natural join
-    # on the unnested rows would fan out the metrics side and break the
-    # row alignment assumed by bind_cols() below
+    # Clean and unnest the raw parameters data, then write the results to S3
     bind_cols(
       read_parquet(paths$output$parameter_raw$local) %>%
         tidyr::unnest(cols = .metrics) %>%
         mutate(run_id = !!run_id) %>%
+        # Notes aren't keyed to configs (tune records one per fit, e.g. custom
+        # objective warnings), so collapse them to one row per resample +
+        # iteration before joining. Joining them unnested would fan out the
+        # metrics rows and break the bind_cols() alignment below
         left_join(
           read_parquet(paths$output$parameter_raw$local) %>%
             select(id, .iter, .notes) %>%

--- a/renv.lock
+++ b/renv.lock
@@ -913,13 +913,13 @@
     },
     "lightsnip": {
       "Package": "lightsnip",
-      "Version": "0.0.6",
+      "Version": "0.0.7",
       "Source": "GitHub",
       "RemoteType": "github",
       "RemoteUsername": "ccao-data",
       "RemoteRepo": "lightsnip",
       "RemoteRef": "master",
-      "RemoteSha": "2720ad973c990ad64ac7e6bb632389ff9f2a2675",
+      "RemoteSha": "855d3641dffb95e03b88d7d8f5f9828486fe981f",
       "RemoteHost": "api.github.com",
       "Requirements": [
         "butcher",
@@ -933,7 +933,7 @@
         "tibble",
         "zip"
       ],
-      "Hash": "c3e596514cefa9e44744f6ae355d249d"
+      "Hash": "5c9cb6c2ca452f669afd0ed45edf8cd7"
     },
     "listenv": {
       "Package": "listenv",


### PR DESCRIPTION
This is more or less an exact port of https://github.com/ccao-data/model-res-avm/pull/475, with the exception of a latent CV bug that was activated with this change.

For details on model performance, see https://github.com/ccao-data/enterprise-intelligence/pull/482 or the model report for the cv run with rho = 2 for run id: `2026-07-16-stoic-maya`